### PR TITLE
Add details per city to votes

### DIFF
--- a/src/components/votes/ccip-020.tsx
+++ b/src/components/votes/ccip-020.tsx
@@ -17,8 +17,8 @@ import { useAtomValue } from "jotai";
 import { useCcip020VoteData } from "../../hooks/use-ccip-020-vote-data";
 import { useCcip020VoteActions } from "../../hooks/use-ccip-020-vote-actions";
 import { formatMicroAmount } from "../../store/common";
-import { hasVotedAtom } from "../../store/ccip-020";
-import VoteProgressBar from "./vote-progress-bar";
+import { Ccip020VoteTotals, hasVotedAtom } from "../../store/ccip-020";
+import VoteProgressBarV2 from "./vote-progress-bar-v2";
 
 function VoteButtons() {
   const { voteYes, voteNo, isRequestPending } = useCcip020VoteActions();
@@ -98,22 +98,25 @@ function CCIP020() {
         <Stack direction={["column", "row"]} justifyContent="space-between">
           <Stat>
             <StatLabel>Yes Vote Count</StatLabel>
-            <StatNumber>
+            <StatNumber
+              title={`MIA ${voteTotals.data?.mia.totalVotesYes} / NYC ${voteTotals.data?.nyc.totalVotesYes}`}
+            >
               {voteTotals.data?.totals.totalVotesYes ?? <Spinner />}
             </StatNumber>
           </Stat>
           <Stat>
             <StatLabel>No Vote Count</StatLabel>
-            <StatNumber>
+            <StatNumber
+              title={`MIA ${voteTotals.data?.mia.totalVotesNo} / NYC ${voteTotals.data?.nyc.totalVotesNo}`}
+            >
               {voteTotals.data?.totals.totalVotesNo ?? <Spinner />}
             </StatNumber>
           </Stat>
         </Stack>
       </Box>
-      <VoteProgressBar
-        yesTotal={voteTotals.data?.totals.totalAmountYes}
-        noTotal={voteTotals.data?.totals.totalAmountNo}
-      />
+      {voteTotals.data && (
+        <VoteProgressBarV2 props={voteTotals.data as Ccip020VoteTotals} />
+      )}
       <Divider />
       <Stack direction={["column", "row"]} justifyContent="space-between">
         <Text fontWeight="bold">Related CCIPs:</Text>

--- a/src/components/votes/vote-progress-bar-v2.tsx
+++ b/src/components/votes/vote-progress-bar-v2.tsx
@@ -1,0 +1,44 @@
+import { Box, Progress, Text, useColorModeValue } from "@chakra-ui/react";
+import { formatMicroAmount } from "../../store/common";
+import { Ccip020VoteTotals } from "../../store/ccip-020";
+
+interface VoteProgressBarV2Props {
+  props: Ccip020VoteTotals;
+}
+
+function VoteProgressBarV2({ props }: VoteProgressBarV2Props) {
+  console.log(JSON.stringify(props, null, 2));
+  const totalVotes = props.totals.totalVotesYes + props.totals.totalVotesNo;
+  const yesVotePercentage = (props.totals.totalAmountYes / totalVotes) * 100;
+
+  return (
+    <Box width="100%">
+      <Progress
+        value={yesVotePercentage}
+        size="lg"
+        bgColor={useColorModeValue("red.500", "red.200")}
+        colorScheme="green"
+      />
+      <Box display="flex" flexWrap="wrap" justifyContent="space-between" mt={2}>
+        <Text
+          title={`MIA ${formatMicroAmount(
+            props.mia.totalAmountYes
+          )} / NYC ${formatMicroAmount(props.nyc.totalAmountYes)}`}
+          color={useColorModeValue("green.500", "green.200")}
+        >{`Yes: ${formatMicroAmount(
+          props.totals.totalAmountYes
+        )} CityCoins`}</Text>
+        <Text
+          title={`MIA ${formatMicroAmount(
+            props.mia.totalAmountNo
+          )} / NYC ${formatMicroAmount(props.nyc.totalAmountNo)}`}
+          color={useColorModeValue("red.500", "red.200")}
+        >{`No: ${formatMicroAmount(
+          props.totals.totalAmountNo
+        )} CityCoins`}</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export default VoteProgressBarV2;

--- a/src/store/ccip-020.ts
+++ b/src/store/ccip-020.ts
@@ -25,7 +25,7 @@ export type CityVoteRecord = {
 export type Ccip020VoteTotals = {
   mia: CityVoteRecord;
   nyc: CityVoteRecord;
-  total: CityVoteRecord;
+  totals: CityVoteRecord;
 };
 
 export type Ccip020VoterInfo = {


### PR DESCRIPTION
Per the post in Discord:
> Flagging that the new voting method shows results a little differently than before, and since votes are counted per city the total number of votes isn't the same as past proposals. This doesn't look like it will affect the outcome as the amounts are still correct but it does display a little differently, more notes below:
> - right now we're at 68 yes votes and 2 no total votes
> - the contract data per city shows that as 30 MIA / 38 NYC yes votes and 1 MIA / 1 NYC no votes
> - the vote amounts per city for yes/no add up as expected to the totals

The titles for the total vote counts and total vote amounts code will now display on hover with the amounts for MIA/NYC.