### PR TITLE
Add mining tx analysis and claim logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/styled": "^11.11.0",
         "@micro-stacks/react": "^1.0.9",
         "@stacks/stacks-blockchain-api-types": "^7.10.0",
+        "@stacks/transactions": "^6.15.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^14.4.3",
@@ -4978,10 +4979,71 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@stacks/common": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@stacks/common/-/common-6.13.0.tgz",
+      "integrity": "sha512-wwzyihjaSdmL6NxKvDeayy3dqM0L0Q2sawmdNtzJDi0FnXuJGm5PeapJj7bEfcI9XwI7Bw5jZoC6mCn9nc5YIw==",
+      "dependencies": {
+        "@types/bn.js": "^5.1.0",
+        "@types/node": "^18.0.4"
+      }
+    },
+    "node_modules/@stacks/common/node_modules/@types/node": {
+      "version": "18.19.33",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.33.tgz",
+      "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@stacks/network": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/@stacks/network/-/network-6.13.0.tgz",
+      "integrity": "sha512-Ss/Da4BNyPBBj1OieM981fJ7SkevKqLPkzoI1+Yo7cYR2df+0FipIN++Z4RfpJpc8ne60vgcx7nJZXQsiGhKBQ==",
+      "dependencies": {
+        "@stacks/common": "^6.13.0",
+        "cross-fetch": "^3.1.5"
+      }
+    },
     "node_modules/@stacks/stacks-blockchain-api-types": {
       "version": "7.10.0",
       "resolved": "https://registry.npmjs.org/@stacks/stacks-blockchain-api-types/-/stacks-blockchain-api-types-7.10.0.tgz",
       "integrity": "sha512-LfDishvEsmDJ6OXfgohkOIIsLTwvKVn3NKELaWTaZndN2Pucsk3Uz8NPDhVM5Ij1rGjFGT2bwcHNoGE7k3GhxQ=="
+    },
+    "node_modules/@stacks/transactions": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-6.15.0.tgz",
+      "integrity": "sha512-P6XKDcqqycPy+KBJBw8+5N+u57D8moJN7msYdde1gYXERmvOo9ht/MNREWWQ7SAM7Nlhau5mpezCdYCzXOCilQ==",
+      "dependencies": {
+        "@noble/hashes": "1.1.5",
+        "@noble/secp256k1": "1.7.1",
+        "@stacks/common": "^6.13.0",
+        "@stacks/network": "^6.13.0",
+        "c32check": "^2.0.0",
+        "lodash.clonedeep": "^4.5.0"
+      }
+    },
+    "node_modules/@stacks/transactions/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@stacks/transactions/node_modules/@noble/secp256k1": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.1.tgz",
+      "integrity": "sha512-hOUk6AyBFmqVrv7k5WAw/LpszxVbj9gGN4JRkIX52fdFAj1UA61KXmZDvqVEm+pOyec3+fIeZB02LYa/pWOArw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@surma/rollup-plugin-off-main-thread": {
       "version": "2.2.3",
@@ -5504,6 +5566,14 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/bn.js": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.5.tgz",
+      "integrity": "sha512-V46N0zwKRF5Q00AZ6hWtN0T8gGmDUaUzLWQvHFo5yThtVwK/VCenFY3wXVbOvNfajEpsTfQM4IN9k/d6gUVX3A==",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -6988,6 +7058,11 @@
     "node_modules/base-64": {
       "version": "0.1.0"
     },
+    "node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
     "node_modules/batch": {
       "version": "0.6.1",
       "license": "MIT"
@@ -7165,6 +7240,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c32check": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/c32check/-/c32check-2.0.0.tgz",
+      "integrity": "sha512-rpwfAcS/CMqo0oCqDf3r9eeLgScRE3l/xHDCXhM3UyrfvIn7PrLq63uHh7yYbv8NzaZn5MVsVhIRpQ+5GZ5HyA==",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "base-x": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -7587,6 +7674,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
+      "dependencies": {
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -14381,6 +14476,11 @@
       "version": "4.17.21",
       "license": "MIT"
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ=="
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT"
@@ -18731,6 +18831,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@emotion/styled": "^11.11.0",
     "@micro-stacks/react": "^1.0.9",
     "@stacks/stacks-blockchain-api-types": "^7.10.0",
+    "@stacks/transactions": "^6.15.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^14.4.3",

--- a/src/components/tabs/mining-claims.tsx
+++ b/src/components/tabs/mining-claims.tsx
@@ -1,11 +1,13 @@
-import { Heading, Stack } from "@chakra-ui/react";
-import ComingSoon from "../coming-soon";
+import { Heading, Stack, Text } from "@chakra-ui/react";
+import { miningBlocksToClaimPerCityAtom } from "../../store/citycoins";
+import { useAtomValue } from "jotai";
 
 function MiningClaims() {
+  const miningBlocksToClaim = useAtomValue(miningBlocksToClaimPerCityAtom);
   return (
     <Stack spacing={4}>
       <Heading>CityCoins Mining Claims</Heading>
-      <ComingSoon />
+      <Text>{JSON.stringify(miningBlocksToClaim)}</Text>
     </Stack>
   );
 }

--- a/src/components/transaction-list.tsx
+++ b/src/components/transaction-list.tsx
@@ -145,8 +145,8 @@ function TransactionFunctionArgs({
     <Stack>
       <Text fontWeight="bold">Function Arguments</Text>
       <List spacing={2}>
-        {functionArgs.map((arg) => (
-          <ListItem key={arg.hex}>
+        {functionArgs.map((arg, idx) => (
+          <ListItem key={idx}>
             <Text>Name: {arg.name}</Text>
             <Text>Type: {arg.type}</Text>
             <Text>Repr: {arg.repr}</Text>

--- a/src/store/citycoins.ts
+++ b/src/store/citycoins.ts
@@ -93,12 +93,11 @@ function checkTransactionForCity(
   }
 }
 
-function getBlockHeightsFromTransactions(
+function getBlockHeightsFromMiningTransactions(
   transactions: ContractCallTransaction[]
 ): number[] {
   const blockHeights: number[] = [];
   transactions.forEach((tx) => {
-    console.log("evaluating a tx for block heights");
     // handle single mining call
     if (
       tx.contract_call.function_name === "mine-tokens" &&
@@ -146,11 +145,18 @@ function getBlockHeightsFromTransactions(
     }
     console.log(
       "unhandled mining tx",
+      tx.contract_call.contract_id,
       tx.contract_call.function_name,
       tx.contract_call.function_args
     );
   });
   return blockHeights;
+}
+
+function getBlockHeightsFromMiningClaimTransactions(
+  transactions: ContractCallTransaction[]
+): number[] {
+  return [];
 }
 
 // MINING TRANSACTIONS
@@ -214,11 +220,22 @@ export const miningBlocksToClaimPerCityAtom = atom((get) => {
   const { miaMiningTransactions, nycMiningTransactions } = get(
     miningTransactionsPerCityAtom
   );
-  const miaBlockHeights = getBlockHeightsFromTransactions(
+  const miaBlockHeightsFromMining = getBlockHeightsFromMiningTransactions(
     miaMiningTransactions
   );
-  const nycBlockHeights = getBlockHeightsFromTransactions(
+  const nycBlockHeightsFromMining = getBlockHeightsFromMiningTransactions(
     nycMiningTransactions
+  );
+  const miaBlockHeightsFromMiningClaims =
+    getBlockHeightsFromMiningClaimTransactions(miaMiningTransactions);
+  const nycBlockHeightsFromMiningClaims =
+    getBlockHeightsFromMiningClaimTransactions(nycMiningTransactions);
+  // create an object with any block heights in mining that are not in mining claims
+  const miaBlockHeights = miaBlockHeightsFromMining.filter(
+    (height) => !miaBlockHeightsFromMiningClaims.includes(height)
+  );
+  const nycBlockHeights = nycBlockHeightsFromMining.filter(
+    (height) => !nycBlockHeightsFromMiningClaims.includes(height)
   );
   return { miaBlockHeights, nycBlockHeights };
 });

--- a/src/store/citycoins.ts
+++ b/src/store/citycoins.ts
@@ -273,7 +273,7 @@ export const miningClaimTransactionsAtom = atom(
           tx.contract_call.function_name,
           miningClaimTransactionCalls
         )
-    );
+    ) as ContractCallTransaction[];
   }
 );
 
@@ -302,7 +302,7 @@ export const stackingTransactionsAtom = atom(
           tx.contract_call.function_name,
           stackingTransactionCalls
         )
-    );
+    ) as ContractCallTransaction[];
   }
 );
 
@@ -337,7 +337,7 @@ export const stackingClaimTransactionsAtom = atom(
           tx.contract_call.function_name,
           stackingClaimTransactionCalls
         )
-    );
+    ) as ContractCallTransaction[];
   }
 );
 
@@ -372,6 +372,6 @@ export const votingTransactionsAtom = atom(
           tx.contract_call.function_name,
           votingTransactionCalls
         )
-    );
+    ) as ContractCallTransaction[];
   }
 );


### PR DESCRIPTION
This PR builds on the downloaded TX list to filter out block heights that haven't been claimed yet.

Includes:
- derived atom that splits transactions by city (wip)
- helper functions to extract block heights from:
    - mining calls, to compute blocks mined
    - mining claim calls, to compute blocks claimed for
- data laid out on the mining claim tab (wip)

Since the contracts follow different formats there are still some evolving patterns here, and once working we can apply the same logic to stacking transactions / claims.

> Note: Looking at this while I type it up, probably worth renaming derived atoms and logic around `blocksMined` and `blocksClaimed` to start, then use those two to derive `blocksToClaim`.