### PR TITLE
Fix progress bar bug

### DIFF
--- a/src/components/votes/vote-progress-bar-v2.tsx
+++ b/src/components/votes/vote-progress-bar-v2.tsx
@@ -8,7 +8,7 @@ interface VoteProgressBarV2Props {
 
 function VoteProgressBarV2({ props }: VoteProgressBarV2Props) {
   // console.log(JSON.stringify(props, null, 2));
-  const totalVotes = props.totals.totalVotesYes + props.totals.totalVotesNo;
+  const totalVotes = props.totals.totalAmountYes + props.totals.totalAmountNo;
   const yesVotePercentage = (props.totals.totalAmountYes / totalVotes) * 100;
 
   return (


### PR DESCRIPTION
While updating the progress bar for CCIP-022 in https://github.com/boomcrypto/citycoins2/commit/8884ee5b961ed6bb4bcc8a4386a47abf9468f656 found a similar bug in the display for CCIP-020. This PR switches the totals to use the amount not the total count of vote.