### PR TITLE
Add token stats and overall progress bar

### DIFF
--- a/src/components/tabs/redeem-nyc.tsx
+++ b/src/components/tabs/redeem-nyc.tsx
@@ -257,7 +257,7 @@ function RedeemNYC() {
               <Stat>
                 <StatLabel>Redemption Ratio</StatLabel>
                 <StatNumber>
-                  {redemptionInfo.redemptionRatio / MICRO(6)}
+                  {redemptionInfo.redemptionRatio / MICRO(8)}
                 </StatNumber>
               </Stat>
             </StatGroup>

--- a/src/components/tabs/redeem-nyc.tsx
+++ b/src/components/tabs/redeem-nyc.tsx
@@ -21,6 +21,8 @@ import {
   Divider,
   useToast,
   Checkbox,
+  Box,
+  Progress,
 } from "@chakra-ui/react";
 import { atom, useAtom, useAtomValue } from "jotai";
 import { LuExternalLink, LuRepeat } from "react-icons/lu";
@@ -32,6 +34,7 @@ import {
   nycTotalSupplyInfoAtom,
   redemptionForBalanceAtom,
   redemptionInfoAtom,
+  redemptionProgressAtom,
   totalBalanceNYCAtom,
   v1BalanceNYCAtom,
   v2BalanceNYCAtom,
@@ -58,6 +61,7 @@ function RedeemNYC() {
     redemptionForBalanceAtom
   );
   const [redemptionInfo, setRedemptionInfo] = useAtom(redemptionInfoAtom);
+  const redemptionProgress = useAtomValue(redemptionProgressAtom);
   const [nycTotalSupply, setNycTotalSupply] = useAtom(nycTotalSupplyInfoAtom);
   const ccd012TxId = useAtomValue(ccd012TxIdAtom);
 
@@ -289,6 +293,17 @@ function RedeemNYC() {
                 </StatNumber>
               </Stat>
             </StatGroup>
+
+            {redemptionProgress && (
+              <>
+                <Text fontSize="sm">
+                  NYC Redemption Progress: {redemptionProgress.toFixed(2)}%
+                </Text>
+                <Box width="100%">
+                  <Progress value={redemptionProgress} size="lg" />
+                </Box>
+              </>
+            )}
           </Stack>
         ) : (
           <Button onClick={setRedemptionInfo}>Get Redemption Info</Button>

--- a/src/components/tabs/redeem-nyc.tsx
+++ b/src/components/tabs/redeem-nyc.tsx
@@ -29,6 +29,7 @@ import { stxAddressAtom } from "../../store/stacks";
 import {
   ccd012TxIdAtom,
   MICRO,
+  nycTotalSupplyInfoAtom,
   redemptionForBalanceAtom,
   redemptionInfoAtom,
   totalBalanceNYCAtom,
@@ -57,6 +58,7 @@ function RedeemNYC() {
     redemptionForBalanceAtom
   );
   const [redemptionInfo, setRedemptionInfo] = useAtom(redemptionInfoAtom);
+  const [nycTotalSupply, setNycTotalSupply] = useAtom(nycTotalSupplyInfoAtom);
   const ccd012TxId = useAtomValue(ccd012TxIdAtom);
 
   const { redeemNycCall, isRequestPending } = useCcd012RedeemNyc();
@@ -290,6 +292,57 @@ function RedeemNYC() {
           </Stack>
         ) : (
           <Button onClick={setRedemptionInfo}>Get Redemption Info</Button>
+        )}
+      </Stack>
+
+      <Divider />
+
+      <Stack>
+        <Heading>NYC Token Info</Heading>
+        {nycTotalSupply ? (
+          // sample object
+          // {"blockHeight":"156958","contractBalance":"15519436600244","currentContractBalance":"10790341594479","redemptionRatio":"291064","redemptionsEnabled":true,"totalRedeemed":"4729095005765","totalSupply":"5331965209999999"}
+          <Stack spacing={4}>
+            <Button leftIcon={<LuRepeat />} onClick={setNycTotalSupply}>
+              Refresh Token Info
+            </Button>
+            <StatGroup>
+              <Stat>
+                <StatLabel>NYC V1 Supply</StatLabel>
+                <StatNumber>{formatAmount(nycTotalSupply.supplyV1)}</StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>NYC V2 Supply</StatLabel>
+                <StatNumber>
+                  {formatMicroAmount(nycTotalSupply.supplyV2)}
+                </StatNumber>
+              </Stat>
+            </StatGroup>
+            <StatGroup>
+              <Stat>
+                <StatLabel>NYC Total Supply</StatLabel>
+                <StatNumber>
+                  {formatMicroAmount(nycTotalSupply.totalSupply)}
+                </StatNumber>
+              </Stat>
+              <Stat>
+                <StatLabel>Total Burned</StatLabel>
+                {redemptionInfo ? (
+                  <StatNumber>
+                    {formatMicroAmount(
+                      redemptionInfo.totalSupply - nycTotalSupply.totalSupply
+                    )}
+                  </StatNumber>
+                ) : (
+                  <Text mt={2} fontSize="small">
+                    (none detected)
+                  </Text>
+                )}
+              </Stat>
+            </StatGroup>
+          </Stack>
+        ) : (
+          <Button onClick={setNycTotalSupply}>Get Token Info</Button>
         )}
       </Stack>
 

--- a/src/store/ccd-012.ts
+++ b/src/store/ccd-012.ts
@@ -32,6 +32,12 @@ type AddressNycRedemptionInfo = {
   redemptionClaims: number;
 };
 
+type TokenSupplyInfo = {
+  supplyV1: number;
+  supplyV2: number;
+  totalSupply: number;
+};
+
 /////////////////////////
 // CONSTANTS
 /////////////////////////
@@ -388,7 +394,7 @@ const userRedemptionInfoQueryAtom = atom(async (get) => {
 const getNycTotalSupplyInfoQueryAtom = atom(async () => {
   try {
     const supplyInfo = await getNycTotalSupplyInfo();
-    console.log("supplyInfo", supplyInfo);
+    // console.log("supplyInfo", supplyInfo);
     return supplyInfo;
   } catch (error) {
     throw new Error(
@@ -526,12 +532,6 @@ async function getUserRedemptionInfo(
   return userRedemptionInfoQuery;
 }
 
-type TokenSupplyInfo = {
-  supplyV1: number;
-  supplyV2: number;
-  totalSupply: number;
-};
-
 export async function getNycTotalSupplyInfo(): Promise<TokenSupplyInfo> {
   const totalSupplyV1 = await fetchReadOnlyFunction<bigint>({
     contractAddress: NYC_V1_CONTRACT_ADDRESS,
@@ -541,12 +541,12 @@ export async function getNycTotalSupplyInfo(): Promise<TokenSupplyInfo> {
   });
   const totalSupplyV1Number = getSafeNumberFromBigInt(totalSupplyV1);
 
-  console.log("totalSupplyV1", typeof totalSupplyV1, totalSupplyV1);
-  console.log(
-    "totalSupplyV1Number",
-    typeof totalSupplyV1Number,
-    totalSupplyV1Number
-  );
+  //console.log("totalSupplyV1", typeof totalSupplyV1, totalSupplyV1);
+  //console.log(
+  //  "totalSupplyV1Number",
+  //  typeof totalSupplyV1Number,
+  //  totalSupplyV1Number
+  //);
 
   const totalSupplyV2 = await fetchReadOnlyFunction<bigint>({
     contractAddress: NYC_V2_CONTRACT_ADDRESS,
@@ -556,21 +556,21 @@ export async function getNycTotalSupplyInfo(): Promise<TokenSupplyInfo> {
   });
   const totalSupplyV2Number = getSafeNumberFromBigInt(totalSupplyV2);
 
-  console.log("totalSupplyV2", typeof totalSupplyV2, totalSupplyV2);
-  console.log(
-    "totalSupplyV2Number",
-    typeof totalSupplyV2Number,
-    totalSupplyV2Number
-  );
+  //console.log("totalSupplyV2", typeof totalSupplyV2, totalSupplyV2);
+  //console.log(
+  //  "totalSupplyV2Number",
+  //  typeof totalSupplyV2Number,
+  //  totalSupplyV2Number
+  //);
 
   const totalSupply = totalSupplyV1Number * MICRO(6) + totalSupplyV2Number;
 
-  console.log(
-    "totalSupply",
-    typeof totalSupply,
-    totalSupply,
-    (totalSupply / MICRO(6)).toLocaleString()
-  );
+  //console.log(
+  //  "totalSupply",
+  //  typeof totalSupply,
+  //  totalSupply,
+  //  (totalSupply / MICRO(6)).toLocaleString()
+  //);
 
   return {
     supplyV1: totalSupplyV1Number,

--- a/src/store/ccd-012.ts
+++ b/src/store/ccd-012.ts
@@ -119,6 +119,12 @@ export const ccd012TxIdAtom = atomWithStorage<string | null>(
   null
 );
 
+export const ccd012NycTotalSupplyInfoLocalAtom =
+  atomWithStorage<TokenSupplyInfo | null>(
+    "citycoins-ccd012-nycTotalSupplyInfo",
+    null
+  );
+
 export const ccd012LocalStorageAtoms = [
   ccd012V1BalanceNYCLocalAtom,
   ccd012V2BalanceNYCLocalAtom,
@@ -155,7 +161,7 @@ export const v1BalanceNYCAtom = atom(
     if (balance === undefined) return;
     if (typeof balance === "bigint") {
       try {
-        set(ccd012V1BalanceNYCLocalAtom, getBalanceFromBigint(balance));
+        set(ccd012V1BalanceNYCLocalAtom, getSafeNumberFromBigInt(balance));
       } catch (error) {
         console.error(`Failed to set v1BalanceAtom with bigint: ${error}`);
       }
@@ -174,7 +180,7 @@ export const v2BalanceNYCAtom = atom(
     if (balance === undefined) return;
     if (typeof balance === "bigint") {
       try {
-        set(ccd012V2BalanceNYCLocalAtom, getBalanceFromBigint(balance));
+        set(ccd012V2BalanceNYCLocalAtom, getSafeNumberFromBigInt(balance));
       } catch (error) {
         console.error(`Failed to set v2BalanceAtom with bigint: ${error}`);
       }
@@ -250,6 +256,16 @@ export const userRedemptionInfoAtom = atom(
     const userRedemptionInfo = await get(userRedemptionInfoQueryAtom);
     if (!userRedemptionInfo) return;
     set(ccd012UserRedemptionInfoAtom, userRedemptionInfo);
+  }
+);
+
+export const nycTotalSupplyInfoAtom = atom(
+  // getter
+  (get) => get(ccd012NycTotalSupplyInfoLocalAtom),
+  // setter
+  async (get, set) => {
+    const supplyInfo = await get(getNycTotalSupplyInfoQueryAtom);
+    set(ccd012NycTotalSupplyInfoLocalAtom, supplyInfo);
   }
 );
 
@@ -358,6 +374,18 @@ const userRedemptionInfoQueryAtom = atom(async (get) => {
   }
 });
 
+const getNycTotalSupplyInfoQueryAtom = atom(async () => {
+  try {
+    const supplyInfo = await getNycTotalSupplyInfo();
+    console.log("supplyInfo", supplyInfo);
+    return supplyInfo;
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch NYC total supply info for ${CONTRACT_FQ_NAME}: ${error}`
+    );
+  }
+});
+
 const getStackingDaoRatioQueryAtom = atom(async () => {
   try {
     const ratio = await getStackingDaoRatio();
@@ -373,7 +401,7 @@ const getStackingDaoRatioQueryAtom = atom(async () => {
 // HELPER FUNCTIONS
 /////////////////////////
 
-function getBalanceFromBigint(balance: bigint): number {
+function getSafeNumberFromBigInt(balance: bigint): number {
   const numberBalance = Number(balance);
   if (Number.isSafeInteger(numberBalance)) {
     return numberBalance;
@@ -485,6 +513,59 @@ async function getUserRedemptionInfo(
       true
     );
   return userRedemptionInfoQuery;
+}
+
+type TokenSupplyInfo = {
+  supplyV1: number;
+  supplyV2: number;
+  totalSupply: number;
+};
+
+export async function getNycTotalSupplyInfo(): Promise<TokenSupplyInfo> {
+  const totalSupplyV1 = await fetchReadOnlyFunction<bigint>({
+    contractAddress: NYC_V1_CONTRACT_ADDRESS,
+    contractName: NYC_V1_CONTRACT_NAME,
+    functionName: "get-total-supply",
+    functionArgs: [],
+  });
+  const totalSupplyV1Number = getSafeNumberFromBigInt(totalSupplyV1);
+
+  console.log("totalSupplyV1", typeof totalSupplyV1, totalSupplyV1);
+  console.log(
+    "totalSupplyV1Number",
+    typeof totalSupplyV1Number,
+    totalSupplyV1Number
+  );
+
+  const totalSupplyV2 = await fetchReadOnlyFunction<bigint>({
+    contractAddress: NYC_V2_CONTRACT_ADDRESS,
+    contractName: NYC_V2_CONTRACT_NAME,
+    functionName: "get-total-supply",
+    functionArgs: [],
+  });
+  const totalSupplyV2Number = getSafeNumberFromBigInt(totalSupplyV2);
+
+  console.log("totalSupplyV2", typeof totalSupplyV2, totalSupplyV2);
+  console.log(
+    "totalSupplyV2Number",
+    typeof totalSupplyV2Number,
+    totalSupplyV2Number
+  );
+
+  const totalSupply = totalSupplyV1Number * MICRO(6) + totalSupplyV2Number;
+
+  console.log(
+    "totalSupply",
+    typeof totalSupply,
+    totalSupply,
+    (totalSupply / MICRO(6)).toLocaleString()
+  );
+
+  return {
+    supplyV1: totalSupplyV1Number,
+    supplyV2: totalSupplyV2Number,
+    totalSupply: totalSupply,
+  };
 }
 
 // helper to get the stSTX to STX ratio from the StackingDAO contract

--- a/src/store/ccd-012.ts
+++ b/src/store/ccd-012.ts
@@ -8,7 +8,7 @@ import { stxAddressAtom } from "./stacks";
 // TYPES
 /////////////////////////
 
-type NycRedemptionInfo = {
+export type NycRedemptionInfo = {
   redemptionsEnabled: boolean;
   blockHeight: number;
   totalSupply: number;
@@ -213,6 +213,17 @@ export const redemptionInfoAtom = atom(
   async (get, set) => {
     const redemptionInfo = await get(redemptionInfoQueryAtom);
     set(ccd012RedemptionInfoAtom, redemptionInfo);
+  }
+);
+
+export const redemptionProgressAtom = atom(
+  // getter
+  (get) => {
+    const redemptionInfo = get(redemptionInfoAtom);
+    if (!redemptionInfo) return null;
+    return (
+      (redemptionInfo.totalRedeemed / redemptionInfo.contractBalance) * 100
+    );
   }
 );
 


### PR DESCRIPTION
This PR adds supply information for NYC below the contract information, and a new atom for storing the progress and displaying it as a progress bar below the contract info.

This also corrects a display issue on the ratio where it should be `/ MICRO(8)` not `/ MICRO(6)`. h/t @friedger for catching that!