### PR TITLE
fix: add and use v2 version of contract

### DIFF
--- a/src/components/votes/ccip-025.tsx
+++ b/src/components/votes/ccip-025.tsx
@@ -159,6 +159,12 @@ function CCIP025() {
           >
             ccip025-extend-sunset-period-3
           </Link>
+          <Link
+            href="https://explorer.hiro.so/txid/SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccip025-extend-sunset-period-3-v2?chain=mainnet"
+            isExternal
+          >
+            ccip025-extend-sunset-period-3-v2
+          </Link>
         </Box>
       </Stack>
       <Stack direction={["column", "row"]} justifyContent="space-between">

--- a/src/store/ccip-025.ts
+++ b/src/store/ccip-025.ts
@@ -37,7 +37,7 @@ export type Ccip025VoterInfo = {
 /////////////////////////
 
 export const CONTRACT_ADDRESS = "SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH";
-export const CONTRACT_NAME = "ccip025-extend-sunset-period-3";
+export const CONTRACT_NAME = "ccip025-extend-sunset-period-3-v2";
 export const CONTRACT_FQ_NAME = `${CONTRACT_ADDRESS}.${CONTRACT_NAME}`;
 
 /////////////////////////


### PR DESCRIPTION
Original deployed contract still had the test cycle numbers of u2 and u3, causing it to fail with ERR_NOTHING_STACKED. The V2 contract uses the correct cycles of u82 and u83.