### PR TITLE
Cleanup and restore

### DIFF
--- a/src/components/layout/page-content.tsx
+++ b/src/components/layout/page-content.tsx
@@ -2,9 +2,6 @@ import { Box } from "@chakra-ui/react";
 import { Tabs } from "@chakra-ui/react";
 import { useAtom } from "jotai";
 import { activeTabAtom } from "../../store/common";
-import Dashboard from "../tabs/dashboard";
-import MiningClaims from "../tabs/mining-claims";
-import StackingClaims from "../tabs/stacking-claims";
 import Voting from "../tabs/voting";
 import Mia from "../tabs/mia";
 import Nyc from "../tabs/nyc";
@@ -14,18 +11,12 @@ function Content() {
 
   return (
     <Box width="100%" maxW="1200px">
-      <Tabs.Root value={activeTab} onValueChange={(e) => setActiveTab(e.value)} variant="enclosed">
+      <Tabs.Root value={activeTab} onValueChange={(e) => setActiveTab(e.value)} variant="outline" fitted>
         <Tabs.List>
-          <Tabs.Trigger value="dashboard">Dashboard</Tabs.Trigger>
-          <Tabs.Trigger value="mining-claims">Mining Claims</Tabs.Trigger>
-          <Tabs.Trigger value="stacking-claims">Stacking Claims</Tabs.Trigger>
           <Tabs.Trigger value="voting">Voting</Tabs.Trigger>
           <Tabs.Trigger value="mia">MIA</Tabs.Trigger>
           <Tabs.Trigger value="nyc">NYC</Tabs.Trigger>
         </Tabs.List>
-        <Tabs.Content value="dashboard"><Dashboard /></Tabs.Content>
-        <Tabs.Content value="mining-claims"><MiningClaims /></Tabs.Content>
-        <Tabs.Content value="stacking-claims"><StackingClaims /></Tabs.Content>
         <Tabs.Content value="voting"><Voting /></Tabs.Content>
         <Tabs.Content value="mia"><Mia /></Tabs.Content>
         <Tabs.Content value="nyc"><Nyc /></Tabs.Content>

--- a/src/components/layout/page-content.tsx
+++ b/src/components/layout/page-content.tsx
@@ -1,17 +1,35 @@
-import { Box, Tabs, TabsTrigger } from "@chakra-ui/react";
+import { Box } from "@chakra-ui/react";
+import { Tabs } from "@chakra-ui/react";
 import { useAtom } from "jotai";
 import { activeTabAtom } from "../../store/common";
 import Dashboard from "../tabs/dashboard";
 import MiningClaims from "../tabs/mining-claims";
 import StackingClaims from "../tabs/stacking-claims";
 import Voting from "../tabs/voting";
+import Mia from "../tabs/mia";
+import Nyc from "../tabs/nyc";
 
 function Content() {
-  //const [activeTab, setActiveTab] = useAtom(activeTabAtom);
+  const [activeTab, setActiveTab] = useAtom(activeTabAtom);
 
   return (
     <Box width="100%" maxW="1200px">
-      <Voting />
+      <Tabs.Root value={activeTab} onValueChange={(e) => setActiveTab(e.value)} variant="enclosed">
+        <Tabs.List>
+          <Tabs.Trigger value="dashboard">Dashboard</Tabs.Trigger>
+          <Tabs.Trigger value="mining-claims">Mining Claims</Tabs.Trigger>
+          <Tabs.Trigger value="stacking-claims">Stacking Claims</Tabs.Trigger>
+          <Tabs.Trigger value="voting">Voting</Tabs.Trigger>
+          <Tabs.Trigger value="mia">MIA</Tabs.Trigger>
+          <Tabs.Trigger value="nyc">NYC</Tabs.Trigger>
+        </Tabs.List>
+        <Tabs.Content value="dashboard"><Dashboard /></Tabs.Content>
+        <Tabs.Content value="mining-claims"><MiningClaims /></Tabs.Content>
+        <Tabs.Content value="stacking-claims"><StackingClaims /></Tabs.Content>
+        <Tabs.Content value="voting"><Voting /></Tabs.Content>
+        <Tabs.Content value="mia"><Mia /></Tabs.Content>
+        <Tabs.Content value="nyc"><Nyc /></Tabs.Content>
+      </Tabs.Root>
     </Box >
   );
 }

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -35,9 +35,9 @@ function Mia() {
               >
                 CCIP-026
               </Link>
-              .
+              .{" "}
+              <Text as="span" color="gray.500">Pending approval.</Text>
             </Text>
-            <Text mb={4}>This functionality is pending approval via CCIP-026.</Text>
             <Stack direction="row" gap={4}>
               <Button variant="outline" disabled>Check Eligibility</Button>
               <Button variant="outline" disabled>Execute Redemption</Button>

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -1,0 +1,28 @@
+import { Heading, Stack, Text } from "@chakra-ui/react";
+import { useAtomValue } from "jotai";
+import { stxAddressAtom } from "../../store/stacks";
+import ComingSoon from "../coming-soon";
+import SignIn from "../auth/sign-in";
+
+function Mia() {
+  const stxAddress = useAtomValue(stxAddressAtom);
+
+  if (!stxAddress) {
+    return (
+      <Stack gap={4}>
+        <Heading>MIA Utilities</Heading>
+        <Text>Wallet connection required to access MIA utilities.</Text>
+        <SignIn />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap={4}>
+      <Heading>MIA Utilities</Heading>
+      <ComingSoon />
+    </Stack>
+  );
+}
+
+export default Mia;

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -1,7 +1,6 @@
-import { Heading, Stack, Text } from "@chakra-ui/react";
+import { Accordion, Button, Heading, Stack, Text } from "@chakra-ui/react";
 import { useAtomValue } from "jotai";
 import { stxAddressAtom } from "../../store/stacks";
-import ComingSoon from "../coming-soon";
 import SignIn from "../auth/sign-in";
 
 function Mia() {
@@ -10,8 +9,8 @@ function Mia() {
   if (!stxAddress) {
     return (
       <Stack gap={4}>
-        <Heading>MIA Utilities</Heading>
-        <Text>Wallet connection required to access MIA utilities.</Text>
+        <Heading size="4xl">Tools and Utilities for MIA</Heading>
+        <Text>Wallet connection required to access tools and utilities for MIA.</Text>
         <SignIn />
       </Stack>
     );
@@ -19,8 +18,22 @@ function Mia() {
 
   return (
     <Stack gap={4}>
-      <Heading>MIA Utilities</Heading>
-      <ComingSoon />
+      <Heading size="4xl">Tools and Utilities for MIA</Heading>
+      <Text>Access tools and utilities for MIA below.</Text>
+      <Accordion.Root collapsible defaultValue={["redeem-mia"]}>
+        <Accordion.Item value="redeem-mia">
+          <Accordion.ItemTrigger>
+            <Heading size="xl">Redeem MIA</Heading>
+            <Accordion.ItemIndicator />
+          </Accordion.ItemTrigger>
+          <Accordion.ItemContent>
+            <Stack gap={4}>
+              <Button>Check Eligibility</Button>
+              <Button>Execute Redemption</Button>
+            </Stack>
+          </Accordion.ItemContent>
+        </Accordion.Item>
+      </Accordion.Root>
     </Stack>
   );
 }

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -9,8 +9,8 @@ function Mia() {
   if (!stxAddress) {
     return (
       <Stack gap={4}>
-        <Heading size="4xl">Tools and Utilities for MIA</Heading>
-        <Text>Wallet connection required to access tools and utilities for MIA.</Text>
+        <Heading size="4xl">MIA Tools</Heading>
+        <Text>Wallet connection required to access tools and utilities for MiamiCoin (MIA).</Text>
         <SignIn />
       </Stack>
     );
@@ -18,8 +18,8 @@ function Mia() {
 
   return (
     <Stack gap={4}>
-      <Heading size="4xl">Tools and Utilities for MIA</Heading>
-      <Text>Access tools and utilities for MIA below.</Text>
+      <Heading size="4xl">MIA Tools</Heading>
+      <Text>Access tools and utilities for MiamiCoin (MIA) below.</Text>
       <Accordion.Root collapsible defaultValue={["redeem-mia"]}>
         <Accordion.Item value="redeem-mia">
           <Accordion.ItemTrigger>

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Button, Heading, Stack, Text } from "@chakra-ui/react";
+import { Accordion, Button, Heading, Link, Stack, Text } from "@chakra-ui/react";
 import { useAtomValue } from "jotai";
 import { stxAddressAtom } from "../../store/stacks";
 import SignIn from "../auth/sign-in";
@@ -26,10 +26,21 @@ function Mia() {
             <Heading size="xl">Redeem MIA</Heading>
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
-          <Accordion.ItemContent>
+          <Accordion.ItemContent p={4}>
+            <Text mb={4}>
+              Burn MIA to receive STX per{" "}
+              <Link
+                href="https://github.com/citycoins/governance/pull/50"
+                isExternal
+              >
+                CCIP-026
+              </Link>
+              .
+            </Text>
+            <Text mb={4}>This functionality is pending approval via CCIP-026.</Text>
             <Stack direction="row" gap={4}>
-              <Button variant="outline">Check Eligibility</Button>
-              <Button variant="outline">Execute Redemption</Button>
+              <Button variant="outline" disabled>Check Eligibility</Button>
+              <Button variant="outline" disabled>Execute Redemption</Button>
             </Stack>
           </Accordion.ItemContent>
         </Accordion.Item>

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -27,9 +27,9 @@ function Mia() {
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
           <Accordion.ItemContent>
-            <Stack gap={4}>
-              <Button>Check Eligibility</Button>
-              <Button>Execute Redemption</Button>
+            <Stack direction="row" gap={4}>
+              <Button variant="outline">Check Eligibility</Button>
+              <Button variant="outline">Execute Redemption</Button>
             </Stack>
           </Accordion.ItemContent>
         </Accordion.Item>

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -1,4 +1,4 @@
-import { Accordion, Button, Heading, Stack, Text } from "@chakra-ui/react";
+import { Accordion, Button, Heading, Link, Stack, Text } from "@chakra-ui/react";
 import { useAtomValue } from "jotai";
 import { stxAddressAtom } from "../../store/stacks";
 import SignIn from "../auth/sign-in";
@@ -26,7 +26,17 @@ function Nyc() {
             <Heading size="xl">Redeem NYC</Heading>
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
-          <Accordion.ItemContent>
+          <Accordion.ItemContent p={4}>
+            <Text mb={4}>
+              Burn NYC to receive STX per{" "}
+              <Link
+                href="https://github.com/citycoins/governance/blob/main/ccips/ccip-022/ccip-022-citycoins-treasury-redemption-nyc.md"
+                isExternal
+              >
+                CCIP-022
+              </Link>
+              .
+            </Text>
             <Stack direction="row" gap={4}>
               <Button variant="outline">Check Eligibility</Button>
               <Button variant="outline">Execute Redemption</Button>

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -2,6 +2,9 @@ import { Accordion, Button, Heading, Link, Stack, Text } from "@chakra-ui/react"
 import { useAtomValue } from "jotai";
 import { stxAddressAtom } from "../../store/stacks";
 import SignIn from "../auth/sign-in";
+import { useState } from "react";
+import { fancyFetch, HIRO_API } from "../../store/common";
+import { openContractCall } from "@stacks/connect";
 
 function Nyc() {
   const stxAddress = useAtomValue(stxAddressAtom);
@@ -15,6 +18,59 @@ function Nyc() {
       </Stack>
     );
   }
+
+  const [hasChecked, setHasChecked] = useState(false);
+  const [isEligible, setIsEligible] = useState(false);
+  const [balanceV1, setBalanceV1] = useState(0);
+  const [balanceV2, setBalanceV2] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const NYC_V1_CONTRACT = "placeholder.v1::newyorkcitycoin"; // TODO: Replace with actual contract
+  const NYC_V2_CONTRACT = "placeholder.v2::newyorkcitycoin"; // TODO: Replace with actual contract
+
+  const checkEligibility = async () => {
+    if (!stxAddress) return;
+
+    setIsLoading(true);
+    try {
+      const url = `${HIRO_API}/extended/v1/address/${stxAddress}/balances`;
+      const data = await fancyFetch<any>(url);
+      const v1Balance = parseInt(data.fungible_tokens?.[NYC_V1_CONTRACT]?.balance || "0", 10);
+      const v2Balance = parseInt(data.fungible_tokens?.[NYC_V2_CONTRACT]?.balance || "0", 10);
+
+      setBalanceV1(v1Balance);
+      setBalanceV2(v2Balance);
+      const eligible = v1Balance > 0 || v2Balance > 0;
+      setIsEligible(eligible);
+      setHasChecked(true);
+    } catch (error) {
+      console.error("Error checking eligibility:", error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const executeRedemption = async () => {
+    // TODO: Implement actual redemption logic with real contract details
+    // Assuming the function requires an amount argument, stub with total balance
+    const totalBalance = balanceV1 + balanceV2;
+
+    await openContractCall({
+      contractAddress: "placeholder.address",
+      contractName: "placeholder-name",
+      functionName: "redeem",
+      functionArgs: [
+        // TODO: Use @stacks/transactions to create clarity values, e.g., uintCV(totalBalance)
+        // uintCV(totalBalance),
+      ],
+      onFinish: (data) => {
+        console.log("Transaction finished:", data);
+      },
+      onCancel: () => {
+        console.log("Transaction cancelled");
+      },
+    });
+  };
 
   return (
     <Stack gap={4}>
@@ -38,9 +94,26 @@ function Nyc() {
               .
             </Text>
             <Stack direction="row" gap={4}>
-              <Button variant="outline">Check Eligibility</Button>
-              <Button variant="outline">Execute Redemption</Button>
+              <Button variant="outline" onClick={checkEligibility} isLoading={isLoading}>
+                Check Eligibility
+              </Button>
+              <Button
+                variant="outline"
+                onClick={executeRedemption}
+                isDisabled={!hasChecked || !isEligible || isLoading}
+              >
+                Execute Redemption
+              </Button>
             </Stack>
+            {hasChecked && (
+              <Stack mt={4}>
+                <Text>NYC v1 Balance: {balanceV1}</Text>
+                <Text>NYC v2 Balance: {balanceV2}</Text>
+                <Text>
+                  {isEligible ? "You are eligible for redemption." : "You are not eligible for redemption."}
+                </Text>
+              </Stack>
+            )}
           </Accordion.ItemContent>
         </Accordion.Item>
       </Accordion.Root>

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -27,9 +27,9 @@ function Nyc() {
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
           <Accordion.ItemContent>
-            <Stack gap={4}>
-              <Button>Check Eligibility</Button>
-              <Button>Execute Redemption</Button>
+            <Stack direction="row" gap={4}>
+              <Button variant="outline">Check Eligibility</Button>
+              <Button variant="outline">Execute Redemption</Button>
             </Stack>
           </Accordion.ItemContent>
         </Accordion.Item>

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -9,6 +9,12 @@ import { openContractCall } from "@stacks/connect";
 function Nyc() {
   const stxAddress = useAtomValue(stxAddressAtom);
 
+  const [hasChecked, setHasChecked] = useState(false);
+  const [isEligible, setIsEligible] = useState(false);
+  const [balanceV1, setBalanceV1] = useState(0);
+  const [balanceV2, setBalanceV2] = useState(0);
+  const [isLoading, setIsLoading] = useState(false);
+
   if (!stxAddress) {
     return (
       <Stack gap={4}>
@@ -18,12 +24,6 @@ function Nyc() {
       </Stack>
     );
   }
-
-  const [hasChecked, setHasChecked] = useState(false);
-  const [isEligible, setIsEligible] = useState(false);
-  const [balanceV1, setBalanceV1] = useState(0);
-  const [balanceV2, setBalanceV2] = useState(0);
-  const [isLoading, setIsLoading] = useState(false);
 
   const NYC_V1_CONTRACT = "placeholder.v1::newyorkcitycoin"; // TODO: Replace with actual contract
   const NYC_V2_CONTRACT = "placeholder.v2::newyorkcitycoin"; // TODO: Replace with actual contract

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -1,7 +1,6 @@
-import { Heading, Stack, Text } from "@chakra-ui/react";
+import { Accordion, Button, Heading, Stack, Text } from "@chakra-ui/react";
 import { useAtomValue } from "jotai";
 import { stxAddressAtom } from "../../store/stacks";
-import ComingSoon from "../coming-soon";
 import SignIn from "../auth/sign-in";
 
 function Nyc() {
@@ -10,8 +9,8 @@ function Nyc() {
   if (!stxAddress) {
     return (
       <Stack gap={4}>
-        <Heading>NYC Utilities</Heading>
-        <Text>Wallet connection required to access NYC utilities.</Text>
+        <Heading size="4xl">Tools and Utilities for NYC</Heading>
+        <Text>Wallet connection required to access tools and utilities for NYC.</Text>
         <SignIn />
       </Stack>
     );
@@ -19,8 +18,22 @@ function Nyc() {
 
   return (
     <Stack gap={4}>
-      <Heading>NYC Utilities</Heading>
-      <ComingSoon />
+      <Heading size="4xl">Tools and Utilities for NYC</Heading>
+      <Text>Access tools and utilities for NYC below.</Text>
+      <Accordion.Root collapsible defaultValue={["redeem-nyc"]}>
+        <Accordion.Item value="redeem-nyc">
+          <Accordion.ItemTrigger>
+            <Heading size="xl">Redeem NYC</Heading>
+            <Accordion.ItemIndicator />
+          </Accordion.ItemTrigger>
+          <Accordion.ItemContent>
+            <Stack gap={4}>
+              <Button>Check Eligibility</Button>
+              <Button>Execute Redemption</Button>
+            </Stack>
+          </Accordion.ItemContent>
+        </Accordion.Item>
+      </Accordion.Root>
     </Stack>
   );
 }

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -1,0 +1,28 @@
+import { Heading, Stack, Text } from "@chakra-ui/react";
+import { useAtomValue } from "jotai";
+import { stxAddressAtom } from "../../store/stacks";
+import ComingSoon from "../coming-soon";
+import SignIn from "../auth/sign-in";
+
+function Nyc() {
+  const stxAddress = useAtomValue(stxAddressAtom);
+
+  if (!stxAddress) {
+    return (
+      <Stack gap={4}>
+        <Heading>NYC Utilities</Heading>
+        <Text>Wallet connection required to access NYC utilities.</Text>
+        <SignIn />
+      </Stack>
+    );
+  }
+
+  return (
+    <Stack gap={4}>
+      <Heading>NYC Utilities</Heading>
+      <ComingSoon />
+    </Stack>
+  );
+}
+
+export default Nyc;

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -9,8 +9,8 @@ function Nyc() {
   if (!stxAddress) {
     return (
       <Stack gap={4}>
-        <Heading size="4xl">Tools and Utilities for NYC</Heading>
-        <Text>Wallet connection required to access tools and utilities for NYC.</Text>
+        <Heading size="4xl">NYC Tools</Heading>
+        <Text>Wallet connection required to access tools and utilities for NewYorkCityCoin (NYC).</Text>
         <SignIn />
       </Stack>
     );
@@ -18,8 +18,8 @@ function Nyc() {
 
   return (
     <Stack gap={4}>
-      <Heading size="4xl">Tools and Utilities for NYC</Heading>
-      <Text>Access tools and utilities for NYC below.</Text>
+      <Heading size="4xl">NYC Tools</Heading>
+      <Text>Access tools and utilities for NewYorkCityCoin (NYC) below.</Text>
       <Accordion.Root collapsible defaultValue={["redeem-nyc"]}>
         <Accordion.Item value="redeem-nyc">
           <Accordion.ItemTrigger>

--- a/src/components/tabs/voting.tsx
+++ b/src/components/tabs/voting.tsx
@@ -19,7 +19,7 @@ function Voting() {
     {
       id: "ccip016",
       title: "Vote 12: Missing Payouts (CCIP-016)",
-      status: "active" as const,
+      status: "passed" as const,
       Component: CCIP016,
     },
     {

--- a/src/components/votes/ccip-016.tsx
+++ b/src/components/votes/ccip-016.tsx
@@ -1,108 +1,41 @@
 import {
   Box,
-  Button,
   Link,
-  List,
   Separator,
   Stack,
   Stat,
   Text,
 } from "@chakra-ui/react";
-import { useAtomValue } from "jotai";
-import { useCcip016VoteActions } from "../../hooks/use-ccip-016-vote-actions";
-import { useCcip016VoteData } from "../../hooks/use-ccip-016-vote-data";
-import {
-  Ccip016VoteTotals,
-  CONTRACT_FQ_NAME,
-  CONTRACT_NAME,
-  hasVotedAtom,
-} from "../../store/ccip-016";
-import { formatMicroAmount } from "../../store/common";
-import { stxAddressAtom } from "../../store/stacks";
-import SignIn from "../auth/sign-in";
+import { Ccip016VoteTotals } from "../../store/ccip-016";
 import VoteProgressBarV2 from "./vote-progress-bar-v2";
 
-function VoteButtons() {
-  const { voteYes, voteNo } = useCcip016VoteActions();
-  const hasVoted = useAtomValue(hasVotedAtom);
-  const stxAddress = useAtomValue(stxAddressAtom);
 
-  if (!stxAddress) {
-    return <SignIn />;
-  }
-
-  return (
-    <>
-      <Text fontWeight="bold">{hasVoted ? "Change vote" : "Voting"}:</Text>
-      <Stack direction={["column", "row"]} gap={4}>
-        <Button onClick={voteYes} colorPalette="green" size="lg" mb={4}>
-          Vote Yes
-        </Button>
-        <Button onClick={voteNo} colorPalette="red" size="lg">
-          Vote No
-        </Button>
-      </Stack>
-    </>
-  );
-}
-
-function VoteResult() {
-  const voterInfo = useCcip016VoteData("voterInfo");
-
-  return (
-    <Stack gap={4}>
-      <Text fontWeight="bold">Your Vote:</Text>
-      <List.Root>
-        <List.Item>
-          Recorded Vote: {voterInfo.data?.vote ? "Yes" : "No"}
-        </List.Item>
-        <List.Root>
-          <List.Item>MIA: {formatMicroAmount(voterInfo.data?.mia)}</List.Item>
-          <List.Item>NYC: {formatMicroAmount(voterInfo.data?.nyc)}</List.Item>
-        </List.Root>
-      </List.Root>
-    </Stack>
-  );
-}
 
 function Ccip016() {
-  const voterInfo = useCcip016VoteData("voterInfo");
-  const isVoteActive = useCcip016VoteData("isVoteActive");
-  const voteTotals = useCcip016VoteData("voteTotals");
-  const hasVoted = useAtomValue(hasVotedAtom);
+  const yesVotesMia = 33;
+  const yesVotesNyc = 33;
+  const yesVotesTotal = 66;
 
-  const yesVoteAmountMia = voteTotals.data?.mia.totalAmountYes || 0;
-  const yesVoteAmountNyc = voteTotals.data?.nyc.totalAmountYes || 0;
-  const yesVoteAmountTotal = yesVoteAmountMia + yesVoteAmountNyc;
-
-  const noVoteAmountMia = voteTotals.data?.mia.totalAmountNo || 0;
-  const noVoteAmountNyc = voteTotals.data?.nyc.totalAmountNo || 0;
-  const noVoteAmountTotal = noVoteAmountMia + noVoteAmountNyc;
-
-  const yesVotesMia = voteTotals.data?.mia.totalVotesYes || 0;
-  const yesVotesNyc = voteTotals.data?.nyc.totalVotesYes || 0;
-  const yesVotesTotal = yesVotesMia + yesVotesNyc;
-
-  const noVotesMia = voteTotals.data?.mia.totalVotesNo || 0;
-  const noVotesNyc = voteTotals.data?.nyc.totalVotesNo || 0;
-  const noVotesTotal = noVotesMia + noVotesNyc;
+  const noVotesMia = 0;
+  const noVotesNyc = 0;
+  const noVotesTotal = 0;
 
   const voteTotalsObject: Ccip016VoteTotals = {
     mia: {
-      totalAmountYes: yesVoteAmountMia,
-      totalAmountNo: noVoteAmountMia,
+      totalAmountYes: 1573458694000000,
+      totalAmountNo: 0,
       totalVotesYes: yesVotesMia,
       totalVotesNo: noVotesMia,
     },
     nyc: {
-      totalAmountYes: yesVoteAmountNyc,
-      totalAmountNo: noVoteAmountNyc,
+      totalAmountYes: 1768793837000000,
+      totalAmountNo: 0,
       totalVotesYes: yesVotesNyc,
       totalVotesNo: noVotesNyc,
     },
     totals: {
-      totalAmountYes: yesVoteAmountTotal,
-      totalAmountNo: noVoteAmountTotal,
+      totalAmountYes: 3342252531000000,
+      totalAmountNo: 0,
       totalVotesYes: yesVotesTotal,
       totalVotesNo: noVotesTotal,
     },
@@ -158,11 +91,11 @@ function Ccip016() {
         <Text fontWeight="bold">Related Contracts:</Text>
         <Box textAlign="end">
           <Link
-            href={`https://explorer.hiro.so/txid/${CONTRACT_FQ_NAME}?chain=mainnet`}
+            href={`https://explorer.hiro.so/txid/SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.ccip016-missed-payouts-v3?chain=mainnet`}
             rel="noopener noreferrer"
             target="_blank"
           >
-            {CONTRACT_NAME}
+            ccip016-missed-payouts-v3
           </Link>
         </Box>
       </Stack>
@@ -185,18 +118,6 @@ function Ccip016() {
           bug.
         </Text>
       </Stack>
-
-      {isVoteActive.data && hasVoted ? (
-        <>
-          <Separator />
-          <Text fontWeight="bold">Vote recorded, thank you!</Text>
-          <Text>Refresh to see stats once the tx confirms.</Text>
-        </>
-      ) : (
-        <VoteButtons />
-      )}
-
-      {voterInfo.data && <VoteResult />}
     </Stack>
   );
 }

--- a/src/store/common.ts
+++ b/src/store/common.ts
@@ -25,9 +25,9 @@ export type LoadableDataset<T> = {
 // LOCAL STORAGE ATOMS
 /////////////////////////
 
-export const activeTabAtom = atomWithStorage<number>(
+export const activeTabAtom = atomWithStorage<string>(
   "citycoins-ui-activeTab",
-  4 // default: Voting
+  "voting" // default: Voting
 );
 
 export const commonLocalStorageAtoms = [activeTabAtom];


### PR DESCRIPTION
- fixes #38 
- adds MIA and NYC tab
- adds starters for all logic around redemption

Not working yet - but merging in as a checkpoint and we can continue iterating!