### PR TITLE
Add CCIP-026 voting page

### DIFF
--- a/src/components/tabs/voting.tsx
+++ b/src/components/tabs/voting.tsx
@@ -12,10 +12,17 @@ import Ccip021 from "../votes/ccip-021";
 import Ccip022 from "../votes/ccip-022";
 import Ccip024 from "../votes/ccip-024";
 import Ccip025 from "../votes/ccip-025";
+import Ccip026 from "../votes/ccip-026";
 import CCIP016 from "../votes/ccip-016";
 
 function Voting() {
   const voteItems = [
+    {
+      id: "ccip026",
+      title: "Vote 13: MiamiCoin Burn to Exit (CCIP-026)",
+      status: "passed" as const,
+      Component: Ccip026,
+    },
     {
       id: "ccip016",
       title: "Vote 12: Missing Payouts (CCIP-016)",
@@ -94,7 +101,7 @@ function Voting() {
     <Stack gap={4}>
       <Heading size="4xl">CityCoins Proposals</Heading>
       <Text>View CityCoins proposal and vote details below.</Text>
-      <Accordion.Root collapsible defaultValue={["ccip016"]}>
+      <Accordion.Root collapsible defaultValue={["ccip026"]}>
         {voteItems.map((item) => (
           <Accordion.Item key={item.id} value={item.id}>
             <Accordion.ItemTrigger>

--- a/src/components/votes/ccip-026.tsx
+++ b/src/components/votes/ccip-026.tsx
@@ -1,0 +1,150 @@
+import { Box, Link, Separator, Stack, Stat, Text } from "@chakra-ui/react";
+import { Ccip016VoteTotals } from "../../store/ccip-016";
+import VoteProgressBarV2 from "./vote-progress-bar-v2";
+
+const CCIP_026_CONTRACT =
+  "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.ccip026-miamicoin-burn-to-exit";
+const CCD_013_CONTRACT =
+  "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.ccd013-burn-to-exit-mia";
+const DIRECT_EXECUTE_CONTRACT =
+  "SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd001-direct-execute";
+
+function Ccip026() {
+  const yesVotes = 39;
+  const noVotes = 0;
+  const yesTotal = 1638177567500000;
+  const noTotal = 0;
+
+  const voteTotalsObject: Ccip016VoteTotals = {
+    mia: {
+      totalAmountYes: yesTotal,
+      totalAmountNo: noTotal,
+      totalVotesYes: yesVotes,
+      totalVotesNo: noVotes,
+    },
+    nyc: {
+      totalAmountYes: 0,
+      totalAmountNo: 0,
+      totalVotesYes: 0,
+      totalVotesNo: 0,
+    },
+    totals: {
+      totalAmountYes: yesTotal,
+      totalAmountNo: noTotal,
+      totalVotesYes: yesVotes,
+      totalVotesNo: noVotes,
+    },
+  };
+
+  return (
+    <Stack gap={4}>
+      <Box textAlign={["left", "center"]} p={4}>
+        <Stack
+          direction={["column", "row"]}
+          justifyContent="space-between"
+          mb={[2, 4]}
+        >
+          <Stat.Root>
+            <Stat.Label>MIA Cycles</Stat.Label>
+            <Stat.ValueText>82, 83</Stat.ValueText>
+          </Stat.Root>
+          <Stat.Root>
+            <Stat.Label>Bitcoin Blocks</Stat.Label>
+            <Stat.ValueText>946,772 - 948,788</Stat.ValueText>
+          </Stat.Root>
+        </Stack>
+        <Stack direction={["column", "row"]} justifyContent="space-between">
+          <Stat.Root>
+            <Stat.Label>Yes Vote Count</Stat.Label>
+            <Stat.ValueText title={yesVotes.toString()}>
+              {yesVotes}
+            </Stat.ValueText>
+          </Stat.Root>
+          <Stat.Root>
+            <Stat.Label>No Vote Count</Stat.Label>
+            <Stat.ValueText title={noVotes.toString()}>
+              {noVotes}
+            </Stat.ValueText>
+          </Stat.Root>
+        </Stack>
+      </Box>
+      <VoteProgressBarV2 props={voteTotalsObject} />
+      <Separator />
+      <Stack direction={["column", "row"]} justifyContent="space-between">
+        <Text fontWeight="bold">Execution Status:</Text>
+        <Box textAlign={["left", "end"]}>
+          <Text>Passed; awaiting direct-execute multisig completion.</Text>
+          <Text color="fg.muted" fontSize="sm">
+            The on-chain executable check returns true. Redemption is not enabled yet.
+          </Text>
+        </Box>
+      </Stack>
+      <Stack direction={["column", "row"]} justifyContent="space-between">
+        <Text fontWeight="bold">Related CCIPs:</Text>
+        <Box>
+          <Link
+            href="https://github.com/citycoins/governance/blob/d73c5d9bbd51f785454e60790b4b6be74d42d63d/ccips/ccip-026/ccip-026-miamicoin-burn-to-exit.md"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            CCIP-026
+          </Link>
+        </Box>
+      </Stack>
+      <Stack direction={["column", "row"]} justifyContent="space-between">
+        <Text fontWeight="bold">Related Contracts:</Text>
+        <Box textAlign={["left", "end"]}>
+          <Link
+            href={`https://explorer.hiro.so/txid/${CCIP_026_CONTRACT}?chain=mainnet`}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            ccip026-miamicoin-burn-to-exit
+          </Link>
+          <br />
+          <Link
+            href={`https://explorer.hiro.so/txid/${CCD_013_CONTRACT}?chain=mainnet`}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            ccd013-burn-to-exit-mia
+          </Link>
+          <br />
+          <Link
+            href={`https://explorer.hiro.so/txid/${DIRECT_EXECUTE_CONTRACT}?chain=mainnet`}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            ccd001-direct-execute
+          </Link>
+        </Box>
+      </Stack>
+      <Stack direction={["column", "row"]} justifyContent="space-between">
+        <Text fontWeight="bold">Voting Method:</Text>
+        <Box textAlign={["left", "end"]}>
+          <Text>Merkle snapshot voting</Text>
+          <Text color="fg.muted" fontSize="sm">
+            Snapshot root committed in the proposal contract.
+          </Text>
+        </Box>
+      </Stack>
+      <Stack gap={2}>
+        <Text fontWeight="bold">Details:</Text>
+        <Text>
+          CCIP-026 enables a MiamiCoin burn-to-exit mechanism. Eligible MIA
+          holders voted using a Merkle snapshot from MIA stacking cycles 82 and
+          83. The vote passed with 1,638,177,567.5 MIA voting yes and 0 MIA
+          voting no.
+        </Text>
+        <Text>
+          Once execution receives the required direct-execute signer threshold,
+          the DAO will enable the CCD013 burn-to-exit extension and initialize
+          redemption. The redemption ratio is sized from the MIA mining treasury
+          snapshot, while payouts are made from the MIA rewards treasury.
+        </Text>
+      </Stack>
+    </Stack>
+  );
+}
+
+export default Ccip026;


### PR DESCRIPTION
## Summary
- add CCIP-026 as Vote 13 in the voting tab
- show the deployed CCIP-026 vote contract and CCD013 MIA burn-to-exit extension
- present the vote as passed/read-only, with execution awaiting direct-execute signer threshold
- avoid adding vote action buttons because the deployed vote function requires Merkle snapshot arguments

## Source of truth
- governance doc: ~/dev/citycoins/governance/ccips/ccip-026/ccip-026-miamicoin-burn-to-exit.md
- deployed source: ~/dev/citycoins/clarity-ccip-026/contracts/
- vote contract: SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.ccip026-miamicoin-burn-to-exit
- redemption extension: SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.ccd013-burn-to-exit-mia

## Verification
- npx vitest run
- npm run build
- curl -I http://127.0.0.1:5173/