### PR TITLE
Add dates to proposal rows

### DIFF
--- a/src/components/tabs/voting.tsx
+++ b/src/components/tabs/voting.tsx
@@ -14,6 +14,7 @@ import Ccip024 from "../votes/ccip-024";
 import Ccip025 from "../votes/ccip-025";
 import Ccip026 from "../votes/ccip-026";
 import CCIP016 from "../votes/ccip-016";
+import { getProposalDateLabel } from "../votes/proposal-dates";
 
 function Voting() {
   const voteItems = [
@@ -105,7 +106,11 @@ function Voting() {
         {voteItems.map((item) => (
           <Accordion.Item key={item.id} value={item.id}>
             <Accordion.ItemTrigger>
-              <VoteTitle title={item.title} status={item.status} />
+              <VoteTitle
+                title={item.title}
+                status={item.status}
+                dateLabel={getProposalDateLabel(item.id)}
+              />
               <Accordion.ItemIndicator />
             </Accordion.ItemTrigger>
             <Accordion.ItemContent>

--- a/src/components/votes/__tests__/proposal-dates.test.ts
+++ b/src/components/votes/__tests__/proposal-dates.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatProposalDate,
+  getProposalDateLabel,
+  PROPOSAL_DATES,
+} from "../proposal-dates";
+
+describe("proposal date metadata", () => {
+  it("has dates for every voting row", () => {
+    expect(Object.keys(PROPOSAL_DATES).sort()).toEqual(
+      [
+        "ccip014",
+        "ccip016",
+        "ccip017",
+        "ccip019",
+        "ccip020",
+        "ccip021",
+        "ccip022",
+        "ccip024",
+        "ccip025",
+        "ccip026",
+        "vote-v1",
+        "vote-v2",
+        "vote-v3",
+      ].sort()
+    );
+  });
+
+  it("formats proposal dates without timezone drift", () => {
+    expect(formatProposalDate("2025-02-17")).toBe("Feb 17, 2025");
+  });
+
+  it("returns a display label for known proposal IDs", () => {
+    expect(getProposalDateLabel("ccip026")).toBe("Created Feb 17, 2025");
+  });
+
+  it("returns undefined for unknown proposal IDs", () => {
+    expect(getProposalDateLabel("unknown")).toBeUndefined();
+  });
+});

--- a/src/components/votes/proposal-dates.ts
+++ b/src/components/votes/proposal-dates.ts
@@ -1,0 +1,41 @@
+export type ProposalDateMetadata = {
+  isoDate: string;
+  source: "governance" | "on-chain";
+};
+
+export const PROPOSAL_DATES: Record<string, ProposalDateMetadata> = {
+  ccip026: { isoDate: "2025-02-17", source: "governance" },
+  ccip016: { isoDate: "2023-04-26", source: "governance" },
+  ccip025: { isoDate: "2024-10-23", source: "governance" },
+  ccip024: { isoDate: "2024-08-01", source: "governance" },
+  ccip019: { isoDate: "2024-01-04", source: "governance" },
+  ccip022: { isoDate: "2024-04-23", source: "governance" },
+  ccip020: { isoDate: "2024-03-22", source: "governance" },
+  ccip021: { isoDate: "2024-04-04", source: "governance" },
+  ccip017: { isoDate: "2023-08-31", source: "governance" },
+  ccip014: { isoDate: "2023-04-19", source: "governance" },
+  "vote-v3": { isoDate: "2022-08-15", source: "governance" },
+  "vote-v2": { isoDate: "2022-08-04", source: "governance" },
+  "vote-v1": { isoDate: "2022-03-25", source: "governance" },
+};
+
+const PROPOSAL_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  timeZone: "UTC",
+});
+
+export function formatProposalDate(isoDate: string) {
+  return PROPOSAL_DATE_FORMATTER.format(new Date(`${isoDate}T00:00:00Z`));
+}
+
+export function getProposalDateLabel(proposalId: string) {
+  const metadata = PROPOSAL_DATES[proposalId];
+
+  if (!metadata) {
+    return undefined;
+  }
+
+  return `Created ${formatProposalDate(metadata.isoDate)}`;
+}

--- a/src/components/votes/vote-title.tsx
+++ b/src/components/votes/vote-title.tsx
@@ -16,7 +16,11 @@ function getStatusColor(status: VoteStatus) {
   }
 }
 
-function VoteTitle(props: { title: string; status: VoteStatus }) {
+function VoteTitle(props: {
+  title: string;
+  status: VoteStatus;
+  dateLabel?: string;
+}) {
   return (
     <Box
       as="span"
@@ -25,15 +29,31 @@ function VoteTitle(props: { title: string; status: VoteStatus }) {
       display="flex"
       flexDirection={["column", "row"]}
       justifyContent="space-between"
-      alignItems={["left", "center"]}
+      alignItems={["flex-start", "center"]}
+      gap={[3, 6]}
       textAlign="left"
       py={[8, 4]}
     >
-      <Text mb={[4, 0]} fontSize="xl">
-        {props.title}
-      </Text>
+      <Box as="span" minW={0}>
+        <Text as="span" display="block" fontSize="xl">
+          {props.title}
+        </Text>
+        {props.dateLabel && (
+          <Text
+            as="span"
+            display="block"
+            color="fg.muted"
+            fontSize="sm"
+            fontWeight="medium"
+            mt={1}
+          >
+            {props.dateLabel}
+          </Text>
+        )}
+      </Box>
       <Badge
         minW={100}
+        flexShrink={0}
         fontWeight="bold"
         colorPalette={getStatusColor(props.status)}
         justifyContent="center"


### PR DESCRIPTION
## Summary
- add proposal date metadata for every voting tab row
- show muted created dates under proposal titles with responsive row layout
- add tests for proposal date metadata and timezone-stable formatting

## Verification
- npx vitest run
- npm run build
- Dev server: http://127.0.0.1:5174/

## Visual check
- Attempted Playwright desktop/mobile screenshots, but Chromium could not launch because system libraries are missing (`libatk-1.0.so.0`).
- `npx playwright install-deps chromium` is blocked by sudo password requirements in this environment.
- Manual browser check still needed on the live dev server for desktop and 375px mobile.