### PR TITLE
Add MIA CCD013 redemption flow

### DIFF
--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -10,6 +10,8 @@ import {
   Box,
   Progress,
   HStack,
+  Input,
+  SimpleGrid,
 } from "@chakra-ui/react";
 import { useAtomValue, useSetAtom } from "jotai";
 import {
@@ -23,9 +25,8 @@ import {
 } from "../../store/stacks";
 import SignIn from "../auth/sign-in";
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { fancyFetch, HIRO_API } from "../../store/common";
 import { request } from "@stacks/connect";
-import { AddressBalanceResponse } from "@stacks/stacks-blockchain-api-types";
+import { Cl } from "@stacks/transactions";
 import {
   miaMiningEntriesAtom,
   miaStackingEntriesAtom,
@@ -51,6 +52,14 @@ import {
   executeClaimTransaction,
 } from "../../utilities/claim-transactions";
 import {
+  buildMiaRedeemPostConditions,
+  getCcd013RedemptionInfo,
+  getCcd013UserRedemptionInfo,
+  MAX_MIA_REDEMPTION_PER_TX_UMIA,
+  type Ccd013RedemptionInfo,
+  type Ccd013UserRedemptionInfo,
+} from "../../utilities/contract-reads";
+import {
   PaginatedMiningTable,
   PaginatedStackingTable,
   formatStackedAmount,
@@ -60,6 +69,35 @@ import {
 import { CITY_CLAIMS_CONFIG } from "../../config/city-claims-config";
 
 const config = CITY_CLAIMS_CONFIG.mia;
+
+function formatWholeAmount(value: bigint): string {
+  return value.toLocaleString();
+}
+
+function formatMicroAmount(value: bigint, maximumFractionDigits = 6): string {
+  const whole = value / 1_000_000n;
+  const fraction = value % 1_000_000n;
+  const trimmedFraction = fraction
+    .toString()
+    .padStart(6, "0")
+    .slice(0, maximumFractionDigits)
+    .replace(/0+$/, "");
+
+  return `${whole.toLocaleString()}${trimmedFraction ? `.${trimmedFraction}` : ""}`;
+}
+
+function parseOptionalUmiaInput(value: string): bigint | undefined {
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (!/^\d+$/.test(trimmed)) {
+    throw new Error("Enter a whole uMIA amount.");
+  }
+  const parsed = BigInt(trimmed);
+  if (parsed === 0n) {
+    throw new Error("Enter an amount greater than zero.");
+  }
+  return parsed;
+}
 
 function Mia() {
   const stxAddress = useAtomValue(stxAddressAtom);
@@ -106,11 +144,12 @@ function Mia() {
   );
 
   // Redemption state
-  const [hasChecked, setHasChecked] = useState(false);
-  const [isEligible, setIsEligible] = useState(false);
-  const [balanceV1, setBalanceV1] = useState(0);
-  const [balanceV2, setBalanceV2] = useState(0);
-  const [isLoading, setIsLoading] = useState(false);
+  const [redemptionInfo, setRedemptionInfo] = useState<Ccd013RedemptionInfo | null>(null);
+  const [userRedemptionInfo, setUserRedemptionInfo] = useState<Ccd013UserRedemptionInfo | null>(null);
+  const [manualAmountUmia, setManualAmountUmia] = useState("");
+  const [redemptionStatus, setRedemptionStatus] = useState<"idle" | "loading" | "submitting">("idle");
+  const [redemptionError, setRedemptionError] = useState<string | null>(null);
+  const [redemptionTxid, setRedemptionTxid] = useState<string | null>(null);
   const [claimingId, setClaimingId] = useState<string | null>(null);
 
   // Fetch block heights on mount and when address changes
@@ -162,56 +201,68 @@ function Mia() {
     verifySingleStacking(entry);
   }, [verifySingleStacking]);
 
-  if (!stxAddress) {
-    return (
-      <Stack gap={4}>
-        <Heading size="4xl">{config.symbol}</Heading>
-        <Text>
-          Connect your wallet to access tools and utilities for MiamiCoin ({config.symbol}).
-        </Text>
-        <SignIn />
-      </Stack>
-    );
-  }
-
-  const checkEligibility = async () => {
+  const loadRedemptionPreview = useCallback(async () => {
     if (!stxAddress) return;
 
-    setIsLoading(true);
+    setRedemptionStatus("loading");
+    setRedemptionError(null);
     try {
-      const url = `${HIRO_API}/extended/v1/address/${stxAddress}/balances`;
-      const data = await fancyFetch<AddressBalanceResponse>(url);
-      const v1Balance = parseInt(
-        data.fungible_tokens?.[`${config.v1Contract}::${config.assetId}`]?.balance || "0",
-        10
-      );
-      const v2Balance = parseInt(
-        data.fungible_tokens?.[`${config.v2Contract}::${config.assetId}`]?.balance || "0",
-        10
-      );
+      const amountUmia = parseOptionalUmiaInput(manualAmountUmia);
+      const [globalResult, userResult] = await Promise.all([
+        getCcd013RedemptionInfo(stxAddress),
+        getCcd013UserRedemptionInfo(stxAddress, amountUmia),
+      ]);
 
-      setBalanceV1(v1Balance);
-      setBalanceV2(v2Balance);
-      setIsEligible(v1Balance > 0 || v2Balance > 0);
-      setHasChecked(true);
+      if (!globalResult.ok || !globalResult.data) {
+        throw new Error(globalResult.error || "Unable to load redemption status.");
+      }
+      if (!userResult.ok || !userResult.data) {
+        throw new Error(userResult.error || "Unable to load redemption preview.");
+      }
+
+      setRedemptionInfo(globalResult.data);
+      setUserRedemptionInfo(userResult.data);
     } catch (error) {
-      console.error("Error checking eligibility:", error);
+      const message = error instanceof Error ? error.message : String(error);
+      setRedemptionError(message);
+      console.error("Error loading redemption preview:", error);
     } finally {
-      setIsLoading(false);
+      setRedemptionStatus("idle");
     }
-  };
+  }, [manualAmountUmia, stxAddress]);
+
+  useEffect(() => {
+    loadRedemptionPreview();
+  }, [loadRedemptionPreview]);
 
   const executeRedemption = async () => {
+    if (!stxAddress || !userRedemptionInfo) return;
     const [address, name] = config.redemptionContract.split(".");
+    setRedemptionStatus("submitting");
+    setRedemptionError(null);
+    setRedemptionTxid(null);
     try {
-      await request("stx_callContract", {
+      const result = await request("stx_callContract", {
         contract: `${address}.${name}`,
         functionName: config.redemptionFunction,
-        functionArgs: [],
-        postConditionMode: "allow",
+        functionArgs: [Cl.serialize(Cl.uint(userRedemptionInfo.burnAmountUmia))],
+        postConditions: buildMiaRedeemPostConditions({
+          userAddress: stxAddress,
+          burnAmountV1Mia: userRedemptionInfo.burnAmountV1Mia,
+          burnAmountV2Umia: userRedemptionInfo.burnAmountV2Umia,
+          redemptionAmountUstx: userRedemptionInfo.redemptionAmountUstx,
+        }),
+        postConditionMode: "deny",
       });
+      if (result.txid) {
+        setRedemptionTxid(result.txid);
+      }
     } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setRedemptionError(message);
       console.error("Error executing redemption:", error);
+    } finally {
+      setRedemptionStatus("idle");
     }
   };
 
@@ -239,10 +290,32 @@ function Mia() {
 
   const currentBlock = blockHeights?.stx ?? 0;
   const isVerifying = verificationProgress.isRunning && verificationProgress.city === config.cityName;
+  const redemptionLoading = redemptionStatus === "loading";
+  const redemptionSubmitting = redemptionStatus === "submitting";
+  const redemptionEnabled = redemptionInfo?.redemptionEnabled ?? false;
+  const canRedeem =
+    redemptionEnabled &&
+    !!userRedemptionInfo &&
+    userRedemptionInfo.burnAmountUmia > 0n &&
+    userRedemptionInfo.redemptionAmountUstx > 0n &&
+    !redemptionLoading &&
+    !redemptionSubmitting;
 
   // Count city-specific entries needing verification
   const cityUnverifiedMining = miningNeedingVerification.filter((e) => e.city === config.cityName).length;
   const cityUnverifiedStacking = stackingNeedingVerification.filter((e) => e.city === config.cityName).length;
+
+  if (!stxAddress) {
+    return (
+      <Stack gap={4}>
+        <Heading size="4xl">{config.symbol}</Heading>
+        <Text>
+          Connect your wallet to access tools and utilities for MiamiCoin ({config.symbol}).
+        </Text>
+        <SignIn />
+      </Stack>
+    );
+  }
 
   return (
     <Stack gap={4}>
@@ -401,47 +474,144 @@ function Mia() {
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
           <Accordion.ItemContent p={4}>
-            <Text mb={4}>
-              Burn {config.symbol} to receive STX per{" "}
-              <Link href={config.ccipLink.href} target="_blank">
-                {config.ccipLink.text}
-              </Link>
-              .{config.pendingApproval && (
-                <>
-                  {" "}
-                  <Text as="span" color="fg.muted">
-                    Pending approval.
-                  </Text>
-                </>
-              )}
-            </Text>
-            <Stack direction="row" gap={4}>
-              <Button
-                variant="outline"
-                onClick={checkEligibility}
-                disabled={isLoading}
-              >
-                {isLoading ? "Checking..." : "Check Eligibility"}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={executeRedemption}
-                disabled={!hasChecked || !isEligible || isLoading}
-              >
-                Execute Redemption
-              </Button>
-            </Stack>
-            {hasChecked && (
-              <Stack mt={4}>
-                <Text>{config.symbol} v1 Balance: {balanceV1}</Text>
-                <Text>{config.symbol} v2 Balance: {(balanceV2 / 1_000_000).toFixed(2)}</Text>
-                <Text>
-                  {isEligible
-                    ? "You are eligible for redemption."
-                    : "You are not eligible for redemption."}
+            <Stack gap={4}>
+              <Text>
+                Burn {config.symbol} to receive STX per{" "}
+                <Link href={config.ccipLink.href} target="_blank">
+                  {config.ccipLink.text}
+                </Link>
+                .{" "}
+                <Text as="span" color={redemptionEnabled ? "green.500" : "fg.muted"}>
+                  {redemptionEnabled
+                    ? "Redemption is enabled."
+                    : "Redemption is waiting for direct execution and initialization."}
                 </Text>
-              </Stack>
-            )}
+              </Text>
+
+              {config.pendingApproval && (
+                <Badge alignSelf="flex-start" colorPalette="yellow">
+                  Pending approval
+                </Badge>
+              )}
+
+              <SimpleGrid columns={{ base: 1, md: 3 }} gap={3}>
+                <Box borderWidth="1px" borderRadius="md" p={3}>
+                  <Text fontSize="sm" color="fg.muted">Ratio</Text>
+                  <Text fontWeight="semibold">
+                    {redemptionInfo
+                      ? `${formatMicroAmount(redemptionInfo.redemptionRatio)} STX / MIA`
+                      : "Loading..."}
+                  </Text>
+                </Box>
+                <Box borderWidth="1px" borderRadius="md" p={3}>
+                  <Text fontSize="sm" color="fg.muted">Treasury Snapshot</Text>
+                  <Text fontWeight="semibold">
+                    {redemptionInfo
+                      ? `${formatMicroAmount(redemptionInfo.miningTreasuryUstx)} STX`
+                      : "Loading..."}
+                  </Text>
+                </Box>
+                <Box borderWidth="1px" borderRadius="md" p={3}>
+                  <Text fontSize="sm" color="fg.muted">Remaining STX</Text>
+                  <Text fontWeight="semibold">
+                    {redemptionInfo
+                      ? `${formatMicroAmount(redemptionInfo.currentContractBalance)} STX`
+                      : "Loading..."}
+                  </Text>
+                </Box>
+              </SimpleGrid>
+
+              {redemptionInfo && (
+                <Text fontSize="sm" color="fg.muted">
+                  Initialized at block {formatWholeAmount(redemptionInfo.blockHeight)}.
+                  Total supply snapshot: {formatMicroAmount(redemptionInfo.totalSupply)} MIA.
+                  Redeemed so far: {formatMicroAmount(redemptionInfo.totalRedeemed)} MIA for{" "}
+                  {formatMicroAmount(redemptionInfo.totalTransferred)} STX.
+                </Text>
+              )}
+
+              <Box>
+                <Text fontSize="sm" mb={1}>
+                  Manual amount override (uMIA)
+                </Text>
+                <Input
+                  value={manualAmountUmia}
+                  onChange={(event) => setManualAmountUmia(event.target.value)}
+                  placeholder="Leave blank to redeem all eligible MIA"
+                  inputMode="numeric"
+                />
+                <Text fontSize="xs" color="fg.muted" mt={1}>
+                  Blank previews your full eligible balance, capped at 10,000,000 MIA per transaction.
+                </Text>
+              </Box>
+
+              {userRedemptionInfo && (
+                <Table.Root size="sm" width="100%">
+                  <Table.Body>
+                    <Table.Row>
+                      <Table.Cell>MIA v1 balance</Table.Cell>
+                      <Table.Cell textAlign="right">{formatWholeAmount(userRedemptionInfo.balanceV1Mia)} MIA</Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>MIA v2 balance</Table.Cell>
+                      <Table.Cell textAlign="right">{formatMicroAmount(userRedemptionInfo.balanceV2Umia)} MIA</Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>Combined balance</Table.Cell>
+                      <Table.Cell textAlign="right">{formatMicroAmount(userRedemptionInfo.totalBalanceUmia)} MIA</Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>Already redeemed</Table.Cell>
+                      <Table.Cell textAlign="right">
+                        {formatMicroAmount(userRedemptionInfo.claimedUmia)} MIA for{" "}
+                        {formatMicroAmount(userRedemptionInfo.claimedUstx)} STX
+                      </Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>Burn split</Table.Cell>
+                      <Table.Cell textAlign="right">
+                        {formatWholeAmount(userRedemptionInfo.burnAmountV1Mia)} v1 MIA +{" "}
+                        {formatMicroAmount(userRedemptionInfo.burnAmountV2Umia)} v2 MIA
+                      </Table.Cell>
+                    </Table.Row>
+                    <Table.Row>
+                      <Table.Cell>Expected STX</Table.Cell>
+                      <Table.Cell textAlign="right">{formatMicroAmount(userRedemptionInfo.redemptionAmountUstx)} STX</Table.Cell>
+                    </Table.Row>
+                  </Table.Body>
+                </Table.Root>
+              )}
+
+              {userRedemptionInfo && userRedemptionInfo.burnAmountUmia === MAX_MIA_REDEMPTION_PER_TX_UMIA && (
+                <Text fontSize="sm" color="fg.muted">
+                  Preview is capped at 10,000,000 MIA. Repeat the flow to redeem more.
+                </Text>
+              )}
+
+              {redemptionError && <Text color="red.500">{redemptionError}</Text>}
+              {redemptionTxid && (
+                <Text fontSize="sm" color="fg.muted">
+                  Submitted transaction: {redemptionTxid}
+                </Text>
+              )}
+
+              <HStack gap={4} flexWrap="wrap">
+                <Button
+                  variant="outline"
+                  onClick={loadRedemptionPreview}
+                  disabled={redemptionLoading || redemptionSubmitting}
+                >
+                  {redemptionLoading ? "Refreshing..." : "Refresh Preview"}
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={executeRedemption}
+                  disabled={!canRedeem}
+                >
+                  {redemptionSubmitting ? "Submitting..." : "Redeem MIA"}
+                </Button>
+              </HStack>
+            </Stack>
           </Accordion.ItemContent>
         </Accordion.Item>
 

--- a/src/config/city-claims-config.ts
+++ b/src/config/city-claims-config.ts
@@ -13,7 +13,7 @@ export const CITY_CLAIMS_CONFIG: Record<CityName, CityClaimsConfig> = {
     assetId: "miamicoin",
     v1Contract: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token",
     v2Contract: "SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2",
-    redemptionContract: "SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd012-redemption-mia",
+    redemptionContract: "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.ccd013-burn-to-exit-mia",
     redemptionFunction: "redeem-mia",
     ccipLink: {
       text: "CCIP-026",

--- a/src/utilities/__tests__/ccd013-redemption.test.ts
+++ b/src/utilities/__tests__/ccd013-redemption.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildMiaRedeemPostConditions,
+  mapCcd013RedemptionInfo,
+  mapCcd013UserRedemptionInfo,
+  MIA_REWARDS_TREASURY,
+} from "../contract-reads/ccd013-redemption";
+
+describe("ccd013 redemption helpers", () => {
+  it("maps global redemption info while preserving bigint values", () => {
+    const mapped = mapCcd013RedemptionInfo({
+      "redemption-enabled": true,
+      "block-height": "7754807",
+      "total-supply": "123456789000000",
+      "mining-treasury-ustx": "987654321000000",
+      "current-contract-balance": "456000000",
+      "redemption-ratio": "789",
+      "total-redeemed": "1000000",
+      "total-transferred": "500000",
+    });
+
+    expect(mapped.redemptionEnabled).toBe(true);
+    expect(mapped.blockHeight).toBe(7754807n);
+    expect(mapped.totalSupply).toBe(123456789000000n);
+    expect(mapped.miningTreasuryUstx).toBe(987654321000000n);
+  });
+
+  it("maps user preview balances, burn split, and expected STX", () => {
+    const mapped = mapCcd013UserRedemptionInfo({
+      address: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27",
+      "mia-balances": {
+        "balance-v1-mia": "10",
+        "balance-v2-umia": "1500000",
+        "total-balance-umia": "11500000",
+      },
+      "redemption-amount-ustx": "2300",
+      "burn-amount-umia": "11500000",
+      "burn-amount-v1-mia": "10",
+      "burn-amount-v2-umia": "1500000",
+      "redemption-claims": { umia: "0", ustx: "0" },
+    });
+
+    expect(mapped.balanceV1Mia).toBe(10n);
+    expect(mapped.balanceV2Umia).toBe(1500000n);
+    expect(mapped.totalBalanceUmia).toBe(11500000n);
+    expect(mapped.burnAmountV1Mia).toBe(10n);
+    expect(mapped.burnAmountV2Umia).toBe(1500000n);
+    expect(mapped.redemptionAmountUstx).toBe(2300n);
+  });
+
+  it("builds strict post-conditions for mixed v1/v2 redemption", () => {
+    const pcs = buildMiaRedeemPostConditions({
+      userAddress: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27",
+      burnAmountV1Mia: 10n,
+      burnAmountV2Umia: 1500000n,
+      redemptionAmountUstx: 2300n,
+    });
+
+    expect(pcs).toHaveLength(3);
+    expect(pcs[0]).toMatchObject({
+      type: "ft-postcondition",
+      address: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27",
+      condition: "lte",
+      amount: "10",
+      asset: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27.miamicoin-token::miamicoin",
+    });
+    expect(pcs[1]).toMatchObject({
+      type: "ft-postcondition",
+      address: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27",
+      condition: "lte",
+      amount: "1500000",
+      asset: "SP1H1733V5MZ3SZ9XRW9FKYGEZT0JDGEB8Y634C7R.miamicoin-token-v2::miamicoin",
+    });
+    expect(pcs[2]).toMatchObject({
+      type: "stx-postcondition",
+      address: MIA_REWARDS_TREASURY,
+      condition: "gte",
+      amount: "2300",
+    });
+  });
+
+  it("omits zero-token burn post-conditions while keeping STX guarantee", () => {
+    const pcs = buildMiaRedeemPostConditions({
+      userAddress: "SP466FNC0P7JWTNM2R9T199QRZN1MYEDTAR0KP27",
+      burnAmountV1Mia: 0n,
+      burnAmountV2Umia: 0n,
+      redemptionAmountUstx: 1n,
+    });
+
+    expect(pcs).toHaveLength(1);
+    expect(pcs[0]).toMatchObject({
+      type: "stx-postcondition",
+      address: MIA_REWARDS_TREASURY,
+      condition: "gte",
+      amount: "1",
+    });
+  });
+});

--- a/src/utilities/contract-reads/ccd013-redemption.ts
+++ b/src/utilities/contract-reads/ccd013-redemption.ts
@@ -1,0 +1,170 @@
+import {
+  Cl,
+  ClarityType,
+  Pc,
+  hexToCV,
+  type ClarityValue,
+  type PostCondition,
+} from "@stacks/transactions";
+import { CITY_CLAIMS_CONFIG } from "../../config/city-claims-config";
+import { decodeClarityValues, safeConvertToBigint } from "../clarity";
+import { callReadOnlyFunction, type ContractCallResult } from "../hiro-client";
+
+const MIA_CONFIG = CITY_CLAIMS_CONFIG.mia;
+const [CCD013_ADDRESS, CCD013_NAME] = MIA_CONFIG.redemptionContract.split(".");
+const [MIA_V1_ADDRESS, MIA_V1_NAME] = MIA_CONFIG.v1Contract.split(".");
+const [MIA_V2_ADDRESS, MIA_V2_NAME] = MIA_CONFIG.v2Contract.split(".");
+
+export const CCD013_REDEMPTION_CONTRACT = MIA_CONFIG.redemptionContract;
+export const MIA_REWARDS_TREASURY =
+  "SP8A9HZ3PKST0S42VM9523Z9NV42SZ026V4K39WH.ccd002-treasury-mia-rewards-v3";
+export const MAX_MIA_REDEMPTION_PER_TX_UMIA = 10_000_000n * 1_000_000n;
+
+export interface Ccd013RedemptionInfo {
+  redemptionEnabled: boolean;
+  blockHeight: bigint;
+  totalSupply: bigint;
+  miningTreasuryUstx: bigint;
+  currentContractBalance: bigint;
+  redemptionRatio: bigint;
+  totalRedeemed: bigint;
+  totalTransferred: bigint;
+}
+
+export interface Ccd013UserRedemptionInfo {
+  address: string;
+  balanceV1Mia: bigint;
+  balanceV2Umia: bigint;
+  totalBalanceUmia: bigint;
+  redemptionAmountUstx: bigint;
+  burnAmountUmia: bigint;
+  burnAmountV1Mia: bigint;
+  burnAmountV2Umia: bigint;
+  claimedUmia: bigint;
+  claimedUstx: bigint;
+}
+
+export interface MiaRedeemPostConditionInputs {
+  userAddress: string;
+  burnAmountV1Mia: bigint;
+  burnAmountV2Umia: bigint;
+  redemptionAmountUstx: bigint;
+}
+
+function parseContractResult<T>(
+  hex: string,
+  mapper: (decoded: any) => T
+): ContractCallResult<T> {
+  try {
+    const cv = hexToCV(hex);
+    if (cv.type === ClarityType.ResponseErr) {
+      return { ok: false, error: "Contract read returned an error response" };
+    }
+    return { ok: true, data: mapper(decodeClarityValues(cv, false)) };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function mapCcd013RedemptionInfo(raw: any): Ccd013RedemptionInfo {
+  return {
+    redemptionEnabled: Boolean(raw["redemption-enabled"]),
+    blockHeight: safeConvertToBigint(raw["block-height"]),
+    totalSupply: safeConvertToBigint(raw["total-supply"]),
+    miningTreasuryUstx: safeConvertToBigint(raw["mining-treasury-ustx"]),
+    currentContractBalance: safeConvertToBigint(raw["current-contract-balance"]),
+    redemptionRatio: safeConvertToBigint(raw["redemption-ratio"]),
+    totalRedeemed: safeConvertToBigint(raw["total-redeemed"]),
+    totalTransferred: safeConvertToBigint(raw["total-transferred"]),
+  };
+}
+
+export function mapCcd013UserRedemptionInfo(raw: any): Ccd013UserRedemptionInfo {
+  const balances = raw["mia-balances"] ?? {};
+  const claims = raw["redemption-claims"] ?? {};
+
+  return {
+    address: String(raw.address ?? ""),
+    balanceV1Mia: safeConvertToBigint(balances["balance-v1-mia"] ?? 0n),
+    balanceV2Umia: safeConvertToBigint(balances["balance-v2-umia"] ?? 0n),
+    totalBalanceUmia: safeConvertToBigint(balances["total-balance-umia"] ?? 0n),
+    redemptionAmountUstx: safeConvertToBigint(raw["redemption-amount-ustx"] ?? 0n),
+    burnAmountUmia: safeConvertToBigint(raw["burn-amount-umia"] ?? 0n),
+    burnAmountV1Mia: safeConvertToBigint(raw["burn-amount-v1-mia"] ?? 0n),
+    burnAmountV2Umia: safeConvertToBigint(raw["burn-amount-v2-umia"] ?? 0n),
+    claimedUmia: safeConvertToBigint(claims.umia ?? 0n),
+    claimedUstx: safeConvertToBigint(claims.ustx ?? 0n),
+  };
+}
+
+export async function getCcd013RedemptionInfo(
+  senderAddress = CCD013_ADDRESS
+): Promise<ContractCallResult<Ccd013RedemptionInfo>> {
+  const result = await callReadOnlyFunction(
+    CCD013_ADDRESS,
+    CCD013_NAME,
+    "get-redemption-info",
+    [],
+    senderAddress
+  );
+
+  if (!result.ok || !result.data) {
+    return { ok: false, error: result.error || "No redemption info returned" };
+  }
+
+  return parseContractResult(result.data, mapCcd013RedemptionInfo);
+}
+
+export async function getCcd013UserRedemptionInfo(
+  userAddress: string,
+  amountUmia?: bigint
+): Promise<ContractCallResult<Ccd013UserRedemptionInfo>> {
+  const amountArg: ClarityValue =
+    amountUmia === undefined ? Cl.none() : Cl.some(Cl.uint(amountUmia));
+  const result = await callReadOnlyFunction(
+    CCD013_ADDRESS,
+    CCD013_NAME,
+    "get-user-redemption-info",
+    [Cl.principal(userAddress), amountArg],
+    userAddress
+  );
+
+  if (!result.ok || !result.data) {
+    return { ok: false, error: result.error || "No user redemption info returned" };
+  }
+
+  return parseContractResult(result.data, mapCcd013UserRedemptionInfo);
+}
+
+export function buildMiaRedeemPostConditions(
+  inputs: MiaRedeemPostConditionInputs
+): PostCondition[] {
+  const postConditions: PostCondition[] = [];
+
+  if (inputs.burnAmountV1Mia > 0n) {
+    postConditions.push(
+      Pc.principal(inputs.userAddress)
+        .willSendLte(inputs.burnAmountV1Mia)
+        .ft(`${MIA_V1_ADDRESS}.${MIA_V1_NAME}`, MIA_CONFIG.assetId)
+    );
+  }
+
+  if (inputs.burnAmountV2Umia > 0n) {
+    postConditions.push(
+      Pc.principal(inputs.userAddress)
+        .willSendLte(inputs.burnAmountV2Umia)
+        .ft(`${MIA_V2_ADDRESS}.${MIA_V2_NAME}`, MIA_CONFIG.assetId)
+    );
+  }
+
+  postConditions.push(
+    Pc.principal(MIA_REWARDS_TREASURY)
+      .willSendGte(inputs.redemptionAmountUstx)
+      .ustx()
+  );
+
+  return postConditions;
+}

--- a/src/utilities/contract-reads/index.ts
+++ b/src/utilities/contract-reads/index.ts
@@ -32,3 +32,17 @@ export {
 } from "./dao-stacking";
 
 export { getUserId as daoGetUserId } from "./dao-user-registry";
+
+export {
+  getCcd013RedemptionInfo,
+  getCcd013UserRedemptionInfo,
+  buildMiaRedeemPostConditions,
+  mapCcd013RedemptionInfo,
+  mapCcd013UserRedemptionInfo,
+  CCD013_REDEMPTION_CONTRACT,
+  MIA_REWARDS_TREASURY,
+  MAX_MIA_REDEMPTION_PER_TX_UMIA,
+  type Ccd013RedemptionInfo,
+  type Ccd013UserRedemptionInfo,
+  type MiaRedeemPostConditionInputs,
+} from "./ccd013-redemption";


### PR DESCRIPTION
## Summary
- point MIA redemption at the live CCD013 burn-to-exit contract while keeping the pending approval state
- add CCD013 read helpers for global/user redemption preview data and strict redeem post-conditions
- replace the MIA redemption panel with preview, manual uMIA override, disabled pre-init status, and redeem submission

## Verification
- npm run build
- npx vitest run src/utilities/__tests__/ccd013-redemption.test.ts