### PR TITLE
Fix DAO stacking cycle mapping

### DIFF
--- a/src/components/claims/PaginatedStackingTable.tsx
+++ b/src/components/claims/PaginatedStackingTable.tsx
@@ -24,6 +24,7 @@ const stackingStatusFilterCollection = createListCollection({
     { label: "Locked", value: "locked" },
     { label: "Claimed", value: "claimed" },
     { label: "No Reward", value: "no-reward" },
+    { label: "Unpaid", value: "unpaid" },
     { label: "Unavailable", value: "unavailable" },
   ],
 });

--- a/src/components/claims/StatusBadge.tsx
+++ b/src/components/claims/StatusBadge.tsx
@@ -9,6 +9,7 @@ const STATUS_COLOR_MAP: Record<string, string> = {
   locked: "blue",
   "not-won": "red",
   "no-reward": "orange",
+  unpaid: "yellow",
   unavailable: "red",
   error: "red",
 };
@@ -21,6 +22,7 @@ const STATUS_DISPLAY_MAP: Record<string, string> = {
   locked: "locked",
   "not-won": "not won",
   "no-reward": "no reward",
+  unpaid: "unpaid",
   unavailable: "unavailable",
   error: "error",
 };

--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -676,7 +676,9 @@ function Mia() {
                 <Text fontSize="sm">
                   {stackingSummary.claimable} claimable, {stackingSummary.unverified} unverified,
                   {stackingSummary.error > 0 && ` ${stackingSummary.error} failed,`}
-                  {" "}{stackingSummary.noReward} no reward, {stackingSummary.claimed} claimed
+                  {" "}{stackingSummary.noReward} no reward,
+                  {stackingSummary.unpaid > 0 && ` ${stackingSummary.unpaid} unpaid,`}
+                  {" "}{stackingSummary.claimed} claimed
                 </Text>
                 {cityUnverifiedStacking > 0 && (
                   <Button

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -506,7 +506,9 @@ function Nyc() {
                 <Text fontSize="sm">
                   {stackingSummary.claimable} claimable, {stackingSummary.unverified} unverified,
                   {stackingSummary.error > 0 && ` ${stackingSummary.error} failed,`}
-                  {" "}{stackingSummary.noReward} no reward, {stackingSummary.claimed} claimed
+                  {" "}{stackingSummary.noReward} no reward,
+                  {stackingSummary.unpaid > 0 && ` ${stackingSummary.unpaid} unpaid,`}
+                  {" "}{stackingSummary.claimed} claimed
                 </Text>
                 {cityUnverifiedStacking > 0 && (
                   <Button

--- a/src/config/city-config.ts
+++ b/src/config/city-config.ts
@@ -89,6 +89,7 @@ export interface CityInfo {
 export const VERSIONS: Version[] = ['legacyV1', 'legacyV2', 'daoV1', 'daoV2'];
 export const CYCLE_LENGTH = 2100;
 export const MINING_CLAIM_MATURITY = 100; // blocks after mining before claim eligible
+export const DAO_STACKING_FIRST_BURN_BLOCK = 666050;
 
 export const CITY_IDS: Record<CityName, number> = {
   mia: 1,
@@ -593,6 +594,31 @@ export function getBlockCycle(city: CityName, version: Version, blockHeight: num
   if (blockHeight < genesisBlock) return 0;
   // Use startCycle offset so cycle numbers are absolute across versions
   return startCycle + Math.floor((blockHeight - genesisBlock) / cycleLength);
+}
+
+/**
+ * Calculate the DAO stacking reward cycle for a burn block height.
+ *
+ * Mirrors ccd007-citycoin-stacking:
+ * - get-reward-cycle = (burnHeight - FIRST_STACKING_BLOCK) / REWARD_CYCLE_LENGTH
+ * - stack starts at current reward cycle + 1
+ */
+export function getDaoStackingStartCycle(burnBlockHeight: number): number {
+  if (burnBlockHeight < DAO_STACKING_FIRST_BURN_BLOCK) return 0;
+  return 1 + Math.floor((burnBlockHeight - DAO_STACKING_FIRST_BURN_BLOCK) / CYCLE_LENGTH);
+}
+
+/**
+ * Check if a DAO stacking cycle is complete using burn-chain cycle math.
+ *
+ * The DAO contract allows claiming only when cycle < get-reward-cycle(burn-block-height).
+ */
+export function isDaoStackingClaimEligible(cycle: number, currentBurnBlock: number): boolean {
+  if (currentBurnBlock < DAO_STACKING_FIRST_BURN_BLOCK) return false;
+  const currentRewardCycle = Math.floor(
+    (currentBurnBlock - DAO_STACKING_FIRST_BURN_BLOCK) / CYCLE_LENGTH
+  );
+  return cycle < currentRewardCycle;
 }
 
 /**

--- a/src/store/__tests__/claims.test.ts
+++ b/src/store/__tests__/claims.test.ts
@@ -23,9 +23,13 @@ import type { VerificationStatus, VerificationResult } from "../verification";
 
 // City config imports for testing eligibility
 import {
+  CITY_CONFIG,
   isMiningClaimEligible,
   isStackingClaimEligible,
   getBlockCycle,
+  getDaoStackingStartCycle,
+  getVersionByCycle,
+  isDaoStackingClaimEligible,
   getCycleFirstBlock,
   MINING_CLAIM_MATURITY,
 } from "../../config/city-config";
@@ -214,6 +218,26 @@ describe("getBlockCycle", () => {
   });
 });
 
+describe("DAO stacking cycle helpers", () => {
+  it("should calculate DAO stack start cycle from burn block height", () => {
+    expect(getDaoStackingStartCycle(666050)).toBe(1);
+    expect(getDaoStackingStartCycle(668150)).toBe(2);
+    expect(getDaoStackingStartCycle(779336)).toBe(54);
+  });
+
+  it("should use configured cycle ranges to classify DAO staking cycles", () => {
+    expect(getVersionByCycle("mia", 53)).toBe("daoV1");
+    expect(getVersionByCycle("mia", 54)).toBe("daoV2");
+    expect(getVersionByCycle("nyc", 53)).toBe("daoV1");
+    expect(getVersionByCycle("nyc", 54)).toBe("daoV2");
+  });
+
+  it("should treat DAO cycles as claimable only after the contract reward cycle advances", () => {
+    expect(isDaoStackingClaimEligible(54, 779336)).toBe(false);
+    expect(isDaoStackingClaimEligible(54, 781550)).toBe(true);
+  });
+});
+
 // =============================================================================
 // CYCLE FIRST BLOCK CALCULATION TESTS
 // =============================================================================
@@ -302,6 +326,7 @@ function mapVerificationToMiningStatus(verificationStatus: VerificationStatus): 
     case "verifying":
     case "unverified":
     case "no-reward":
+    case "unpaid":
     default:
       return "unverified";
   }
@@ -315,6 +340,8 @@ function mapVerificationToStackingStatus(verificationStatus: VerificationStatus)
       return "claimed";
     case "no-reward":
       return "no-reward";
+    case "unpaid":
+      return "unpaid";
     case "error":
       return "unavailable";
     case "verifying":
@@ -362,6 +389,10 @@ describe("mapVerificationToStackingStatus", () => {
 
   it('should map "no-reward" to "no-reward"', () => {
     expect(mapVerificationToStackingStatus("no-reward")).toBe("no-reward");
+  });
+
+  it('should map "unpaid" to "unpaid"', () => {
+    expect(mapVerificationToStackingStatus("unpaid")).toBe("unpaid");
   });
 
   it('should map "error" to "unavailable"', () => {
@@ -713,6 +744,7 @@ describe("Summary Computation", () => {
       locked: 0,
       unverified: 0,
       noReward: 0,
+      unpaid: 0,
       unavailable: 0,
     };
 
@@ -733,6 +765,9 @@ describe("Summary Computation", () => {
           break;
         case "no-reward":
           summary.noReward++;
+          break;
+        case "unpaid":
+          summary.unpaid++;
           break;
         case "unavailable":
           summary.unavailable++;
@@ -775,17 +810,19 @@ describe("Summary Computation", () => {
       createStackingEntry(21, "locked"),
       createStackingEntry(22, "unverified"),
       createStackingEntry(23, "no-reward"),
-      createStackingEntry(24, "unavailable"),
+      createStackingEntry(24, "unpaid"),
+      createStackingEntry(25, "unavailable"),
     ];
 
     const summary = computeStackingSummary(entries);
 
-    expect(summary.total).toBe(8);
+    expect(summary.total).toBe(9);
     expect(summary.claimed).toBe(1);
     expect(summary.claimable).toBe(2);
     expect(summary.locked).toBe(2);
     expect(summary.unverified).toBe(1);
     expect(summary.noReward).toBe(1);
+    expect(summary.unpaid).toBe(1);
     expect(summary.unavailable).toBe(1);
   });
 
@@ -893,9 +930,11 @@ describe("Multi-cycle Stacking Entry Creation", () => {
   ): StackingEntry[] {
     const startCycle = getBlockCycle(city, version, txBlockHeight);
     const entries: StackingEntry[] = [];
+    const { endCycle } = CITY_CONFIG[city][version].stacking;
 
     for (let i = 0; i < lockPeriod; i++) {
       const cycle = startCycle + i;
+      if (endCycle !== undefined && cycle > endCycle) continue;
       entries.push({
         txId: "0xtest",
         cycle,
@@ -989,5 +1028,25 @@ describe("Multi-cycle Stacking Entry Creation", () => {
     expect(entries[1].cycle).toBe(2);
     expect(entries[0].status).toBe("unverified");
     expect(entries[1].status).toBe("unverified");
+  });
+
+  it("should not create legacy stacking entries past the legacy contract end cycle", () => {
+    const txBlockHeight = 74189; // MIA legacyV2 cycle 24
+    const lockPeriod = 25;
+    const amountTokens = 1000000000n;
+    const currentBlock = 100000;
+
+    const entries = createStackingEntriesFromTx(
+      txBlockHeight,
+      lockPeriod,
+      amountTokens,
+      currentBlock,
+      "mia",
+      "legacyV2"
+    );
+
+    expect(entries[0].cycle).toBe(24);
+    expect(entries.at(-1)?.cycle).toBe(34);
+    expect(entries.some((entry) => entry.cycle > 34)).toBe(false);
   });
 });

--- a/src/store/__tests__/verification.test.ts
+++ b/src/store/__tests__/verification.test.ts
@@ -325,6 +325,7 @@ describe("Verification Status Mapping", () => {
       "claimable",
       "not-won",
       "no-reward",
+      "unpaid",
       "claimed",
       "error",
     ];

--- a/src/store/claims.ts
+++ b/src/store/claims.ts
@@ -32,7 +32,10 @@ import {
   CITY_CONFIG,
   findContractInfo,
   getBlockCycle,
+  getDaoStackingStartCycle,
+  getVersionByCycle,
   isMiningClaimEligible,
+  isDaoStackingClaimEligible,
   isStackingClaimEligible,
   getAllMiningFunctions,
   getAllMiningClaimFunctions,
@@ -70,6 +73,7 @@ export type StackingStatus =
   | "claimable"    // Verified: has reward to claim
   | "claimed"      // Already claimed (from transaction history)
   | "no-reward"    // Verified: no reward available
+  | "unpaid"       // Verified: DAO cycle has not been paid out
   | "unavailable"; // Failed claim attempt
 
 export interface MiningEntry {
@@ -187,13 +191,71 @@ const MINING_CLAIM_FUNCTIONS = new Set(getAllMiningClaimFunctions());
 const STACKING_FUNCTIONS = new Set(getAllStackingFunctions());
 const STACKING_CLAIM_FUNCTIONS = new Set(getAllStackingClaimFunctions());
 
+function isDaoVersion(version: Version): boolean {
+  return version === "daoV1" || version === "daoV2";
+}
+
+function getStackingStartCycle(
+  city: CityName,
+  version: Version,
+  tx: Transaction
+): number {
+  if (isDaoVersion(version) && tx.burn_block_height) {
+    return getDaoStackingStartCycle(tx.burn_block_height);
+  }
+  return getBlockCycle(city, version, tx.block_height);
+}
+
+function getStackingEntryStatus(
+  city: CityName,
+  version: Version,
+  cycle: number,
+  currentStxBlock: number,
+  currentBurnBlock: number
+): StackingStatus {
+  if (isDaoVersion(version)) {
+    return isDaoStackingClaimEligible(cycle, currentBurnBlock)
+      ? "unverified"
+      : "locked";
+  }
+  return isStackingClaimEligible(city, version, cycle, currentStxBlock)
+    ? "unverified"
+    : "locked";
+}
+
+function getStackingCycleVersion(
+  city: CityName,
+  originalVersion: Version,
+  cycle: number
+): Version | null {
+  if (!isDaoVersion(originalVersion)) {
+    const { endCycle } = CITY_CONFIG[city][originalVersion].stacking;
+    if (endCycle !== undefined && cycle > endCycle) return null;
+    return originalVersion;
+  }
+  return getVersionByCycle(city, cycle) ?? originalVersion;
+}
+
+function getStackingClaimVersion(
+  city: CityName,
+  originalVersion: Version,
+  cycle: number
+): Version {
+  if (!isDaoVersion(originalVersion)) {
+    return originalVersion;
+  }
+  return getVersionByCycle(city, cycle) ?? originalVersion;
+}
+
 /**
  * Processes all transactions in a single pass, caching decoded args.
  * This is the foundation for all claims-related atoms.
  */
 const processedTransactionsAtom = atom((get) => {
   const transactions = get(transactionsAtom);
-  const currentBlock = get(blockHeightsAtom)?.stx ?? 0;
+  const blockHeights = get(blockHeightsAtom);
+  const currentStxBlock = blockHeights?.stx ?? 0;
+  const currentBurnBlock = blockHeights?.btc ?? 0;
 
   // Cache for decoded transaction arguments
   const decodedCache: DecodedTxCache = new Map();
@@ -234,7 +296,7 @@ const processedTransactionsAtom = atom((get) => {
               contractId,
               functionName,
               amountUstx: decoded.amountsUstx[i],
-              status: isMiningClaimEligible(block, currentBlock) ? "unverified" : "pending",
+              status: isMiningClaimEligible(block, currentStxBlock) ? "unverified" : "pending",
             });
           }
         }
@@ -265,27 +327,31 @@ const processedTransactionsAtom = atom((get) => {
       if (decoded && isValidStackingTxArgs(decoded)) {
         const cityVersion = getCityVersionFromContractAndArgs(contractId, decoded);
         if (cityVersion) {
-          const { city, version } = cityVersion;
+          const { city } = cityVersion;
           const lockPeriod = Number(decoded.lockPeriod);
           const amountTokens = decoded.amountToken;
-          const startCycle = getBlockCycle(city, version, tx.block_height);
-          const { endCycle } = CITY_CONFIG[city][version].stacking;
+          const startCycle = getStackingStartCycle(city, cityVersion.version, tx);
 
           for (let i = 0; i < lockPeriod; i++) {
             const cycle = startCycle + i;
-            if (endCycle !== undefined && cycle > endCycle) continue;
+            const cycleVersion = getStackingCycleVersion(city, cityVersion.version, cycle);
+            if (cycleVersion === null) continue;
 
             result.stackingEntries.push({
               txId: tx.tx_id,
               cycle,
               city,
-              version,
+              version: cycleVersion,
               contractId,
               functionName,
               amountTokens,
-              status: isStackingClaimEligible(city, version, cycle, currentBlock)
-                ? "unverified"
-                : "locked",
+              status: getStackingEntryStatus(
+                city,
+                cycleVersion,
+                cycle,
+                currentStxBlock,
+                currentBurnBlock
+              ),
             });
           }
         }
@@ -299,7 +365,12 @@ const processedTransactionsAtom = atom((get) => {
         const cityVersion = getCityVersionFromContractAndArgs(contractId, decoded);
         if (cityVersion) {
           const cycle = Number(decoded.rewardCycle);
-          const key = `${cityVersion.city}-${cityVersion.version}-${cycle}`;
+          const version = getStackingClaimVersion(
+            cityVersion.city,
+            cityVersion.version,
+            cycle
+          );
+          const key = `${cityVersion.city}-${version}-${cycle}`;
 
           if (tx.tx_status === "success") {
             result.claimedStackingCycles.set(key, tx.tx_id);
@@ -375,6 +446,7 @@ function mapVerificationToMiningStatus(
       return "unverified"; // Still show as unverified while checking
     case "unverified":
     case "no-reward":
+    case "unpaid":
     default:
       return "unverified";
   }
@@ -393,6 +465,8 @@ function mapVerificationToStackingStatus(
       return "claimed";
     case "no-reward":
       return "no-reward";
+    case "unpaid":
+      return "unpaid";
     case "error":
       return "unavailable";
     case "verifying":
@@ -612,6 +686,7 @@ export interface CitySummary {
   stackingLocked: number;
   stackingUnverified: number;
   stackingNoReward: number;
+  stackingUnpaid: number;
   stackingUnavailable: number;
 }
 
@@ -634,6 +709,7 @@ const emptySummary = (): CitySummary => ({
   stackingLocked: 0,
   stackingUnverified: 0,
   stackingNoReward: 0,
+  stackingUnpaid: 0,
   stackingUnavailable: 0,
 });
 
@@ -673,6 +749,7 @@ export const claimsSummaryAtom = atom<ClaimsSummary>((get) => {
       case "locked": summary.stackingLocked++; break;
       case "unverified": summary.stackingUnverified++; break;
       case "no-reward": summary.stackingNoReward++; break;
+      case "unpaid": summary.stackingUnpaid++; break;
       case "unavailable": summary.stackingUnavailable++; break;
     }
   }

--- a/src/store/verification.ts
+++ b/src/store/verification.ts
@@ -41,6 +41,7 @@ export type VerificationStatus =
   | "claimable" // Verified: can claim reward
   | "not-won" // Verified: didn't win mining lottery
   | "no-reward" // Verified: no stacking reward available
+  | "unpaid" // Verified: stacking cycle has not been paid out
   | "claimed" // Already claimed
   | "error"; // Verification failed
 
@@ -117,8 +118,11 @@ function getMiningStatusFromResult(result: {
  */
 function getStackingStatusFromResult(result: {
   canClaim: boolean;
+  isPaid?: boolean;
 }): VerificationStatus {
-  return result.canClaim ? "claimable" : "no-reward";
+  if (result.canClaim) return "claimable";
+  if (result.isPaid === false) return "unpaid";
+  return "no-reward";
 }
 
 // =============================================================================
@@ -915,6 +919,7 @@ export const stackingVerificationSummaryAtom = atom((get) => {
     let verifying = 0;
     let claimable = 0;
     let noReward = 0;
+    let unpaid = 0;
     let claimed = 0;
     let error = 0;
 
@@ -951,6 +956,9 @@ export const stackingVerificationSummaryAtom = atom((get) => {
           case "no-reward":
             noReward++;
             break;
+          case "unpaid":
+            unpaid++;
+            break;
           case "claimed":
             claimed++;
             break;
@@ -961,6 +969,6 @@ export const stackingVerificationSummaryAtom = atom((get) => {
       }
     }
 
-    return { locked, unverified, verifying, claimable, noReward, claimed, error, total: entries.length };
+    return { locked, unverified, verifying, claimable, noReward, unpaid, claimed, error, total: entries.length };
   };
 });

--- a/src/utilities/broadcast-sync.ts
+++ b/src/utilities/broadcast-sync.ts
@@ -322,7 +322,7 @@ export function mergeVerificationEntries(
  *
  * Status priority (most to least definitive):
  * 1. claimed (final state)
- * 2. claimable, not-won, no-reward (verified states)
+ * 2. claimable, not-won, no-reward, unpaid (verified states)
  * 3. error (failed but attempted)
  * 4. verifying (in progress)
  * 5. unverified (not started)
@@ -333,6 +333,7 @@ function isMoreDefinitiveStatus(a: string, b: string): boolean {
     claimable: 4,
     "not-won": 4,
     "no-reward": 4,
+    unpaid: 4,
     error: 3,
     verifying: 2,
     unverified: 1,

--- a/src/utilities/claim-verification.ts
+++ b/src/utilities/claim-verification.ts
@@ -23,6 +23,8 @@ export interface MiningClaimVerification {
 
 export interface StackingClaimVerification {
   reward: number;
+  claimable?: number;
+  isPaid?: boolean;
   canClaim: boolean;
 }
 
@@ -194,20 +196,40 @@ export async function verifyStackingClaim(
     }
 
     if (protocolApi.isDaoVersion(version)) {
-      const result = await protocolApi.getStackingReward(city, userId, cycle);
+      const [rewardResult, stackerResult, paidResult] = await Promise.all([
+        protocolApi.getStackingReward(city, userId, cycle),
+        protocolApi.getStacker(city, userId, cycle),
+        protocolApi.isCyclePaid(city, cycle),
+      ]);
 
-      if (!result.ok) {
+      if (!rewardResult.ok) {
         return {
           success: false,
-          error: { message: result.error || "API request failed", status: result.status },
+          error: { message: rewardResult.error || "API request failed", status: rewardResult.status },
         };
       }
 
-      const reward = result.data?.reward ?? 0;
+      if (!stackerResult.ok) {
+        return {
+          success: false,
+          error: { message: stackerResult.error || "API request failed", status: stackerResult.status },
+        };
+      }
+
+      if (!paidResult.ok) {
+        return {
+          success: false,
+          error: { message: paidResult.error || "API request failed", status: paidResult.status },
+        };
+      }
+
+      const reward = rewardResult.data?.reward ?? 0;
+      const claimable = stackerResult.data?.claimable ?? 0;
+      const isPaid = paidResult.data ?? false;
 
       return {
         success: true,
-        data: { reward, canClaim: reward > 0 },
+        data: { reward, claimable, isPaid, canClaim: reward > 0 || claimable > 0 },
       };
     }
 


### PR DESCRIPTION
## Summary
- Use DAO stacking burn-block cycle math when deriving stack reward cycles
- Map stacking claim transactions to the version for the claimed cycle so shared DAO contracts do not default to daoV1
- Add anonymized cycle/burn-height coverage for DAO stacking boundaries

## Tests
- `npx vitest run src/store/__tests__/claims.test.ts`
- `npm run build`