### PR TITLE
Fix DAO stacking cycle mapping and claims table layout

### DIFF
--- a/src/components/claims/PaginatedMiningTable.tsx
+++ b/src/components/claims/PaginatedMiningTable.tsx
@@ -11,7 +11,6 @@ import {
 } from "@chakra-ui/react";
 import { useState, useEffect, useMemo } from "react";
 import { MiningRow } from "./MiningRow";
-import { VirtualizedMiningTable } from "./VirtualizedMiningTable";
 import type { MiningEntry } from "./types";
 
 const ITEMS_PER_PAGE = 50;
@@ -68,9 +67,6 @@ export function PaginatedMiningTable({
     setPage(0);
   }, [statusFilter, searchBlock]);
 
-  // Use virtualization for large filtered lists
-  const useVirtualization = filteredEntries.length > 100;
-
   if (entries.length === 0) {
     return <Text color="fg.muted">No mining history found.</Text>;
   }
@@ -121,42 +117,32 @@ export function PaginatedMiningTable({
       </HStack>
 
       {/* Table */}
-      {useVirtualization ? (
-        <VirtualizedMiningTable
-          entries={filteredEntries}
-          onClaim={onClaim}
-          onVerify={onVerify}
-          claimingId={claimingId}
-          isVerifying={isVerifying}
-        />
-      ) : (
-        <Table.Root size="sm" width="100%">
-          <Table.Header>
-            <Table.Row>
-              <Table.ColumnHeader>Block</Table.ColumnHeader>
-              <Table.ColumnHeader>Version</Table.ColumnHeader>
-              <Table.ColumnHeader>Commit (STX)</Table.ColumnHeader>
-              <Table.ColumnHeader>Status</Table.ColumnHeader>
-              <Table.ColumnHeader>Action</Table.ColumnHeader>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {paginatedEntries.map((entry) => (
-              <MiningRow
-                key={`${entry.txId}-${entry.block}`}
-                entry={entry}
-                onClaim={onClaim}
-                onVerify={onVerify}
-                claimingId={claimingId}
-                isVerifying={isVerifying}
-              />
-            ))}
-          </Table.Body>
-        </Table.Root>
-      )}
+      <Table.Root size="sm" width="100%">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Block</Table.ColumnHeader>
+            <Table.ColumnHeader>Version</Table.ColumnHeader>
+            <Table.ColumnHeader>Commit (STX)</Table.ColumnHeader>
+            <Table.ColumnHeader>Status</Table.ColumnHeader>
+            <Table.ColumnHeader>Action</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {paginatedEntries.map((entry) => (
+            <MiningRow
+              key={`${entry.txId}-${entry.block}`}
+              entry={entry}
+              onClaim={onClaim}
+              onVerify={onVerify}
+              claimingId={claimingId}
+              isVerifying={isVerifying}
+            />
+          ))}
+        </Table.Body>
+      </Table.Root>
 
       {/* Pagination */}
-      {totalPages > 1 && !useVirtualization && (
+      {totalPages > 1 && (
         <HStack gap={2} justify="center">
           <Button
             size="xs"

--- a/src/components/claims/PaginatedStackingTable.tsx
+++ b/src/components/claims/PaginatedStackingTable.tsx
@@ -11,7 +11,6 @@ import {
 } from "@chakra-ui/react";
 import { useState, useEffect, useMemo } from "react";
 import { StackingRow } from "./StackingRow";
-import { VirtualizedStackingTable } from "./VirtualizedStackingTable";
 import type { StackingEntry } from "./types";
 
 const ITEMS_PER_PAGE = 50;
@@ -71,9 +70,6 @@ export function PaginatedStackingTable({
     setPage(0);
   }, [statusFilter, searchCycle]);
 
-  // Use virtualization for large filtered lists
-  const useVirtualization = filteredEntries.length > 100;
-
   if (entries.length === 0) {
     return <Text color="fg.muted">No stacking history found.</Text>;
   }
@@ -124,44 +120,33 @@ export function PaginatedStackingTable({
       </HStack>
 
       {/* Table */}
-      {useVirtualization ? (
-        <VirtualizedStackingTable
-          entries={filteredEntries}
-          onClaim={onClaim}
-          onVerify={onVerify}
-          claimingId={claimingId}
-          isVerifying={isVerifying}
-          hasUserIds={hasUserIds}
-        />
-      ) : (
-        <Table.Root size="sm" width="100%">
-          <Table.Header>
-            <Table.Row>
-              <Table.ColumnHeader>Cycle</Table.ColumnHeader>
-              <Table.ColumnHeader>Version</Table.ColumnHeader>
-              <Table.ColumnHeader>Stacked</Table.ColumnHeader>
-              <Table.ColumnHeader>Status</Table.ColumnHeader>
-              <Table.ColumnHeader>Action</Table.ColumnHeader>
-            </Table.Row>
-          </Table.Header>
-          <Table.Body>
-            {paginatedEntries.map((entry) => (
-              <StackingRow
-                key={`${entry.txId}-${entry.cycle}`}
-                entry={entry}
-                onClaim={onClaim}
-                onVerify={onVerify}
-                claimingId={claimingId}
-                isVerifying={isVerifying}
-                hasUserIds={hasUserIds}
-              />
-            ))}
-          </Table.Body>
-        </Table.Root>
-      )}
+      <Table.Root size="sm" width="100%">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Cycle</Table.ColumnHeader>
+            <Table.ColumnHeader>Version</Table.ColumnHeader>
+            <Table.ColumnHeader>Stacked</Table.ColumnHeader>
+            <Table.ColumnHeader>Status</Table.ColumnHeader>
+            <Table.ColumnHeader>Action</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {paginatedEntries.map((entry) => (
+            <StackingRow
+              key={`${entry.txId}-${entry.cycle}`}
+              entry={entry}
+              onClaim={onClaim}
+              onVerify={onVerify}
+              claimingId={claimingId}
+              isVerifying={isVerifying}
+              hasUserIds={hasUserIds}
+            />
+          ))}
+        </Table.Body>
+      </Table.Root>
 
       {/* Pagination */}
-      {totalPages > 1 && !useVirtualization && (
+      {totalPages > 1 && (
         <HStack gap={2} justify="center">
           <Button
             size="xs"

--- a/src/store/claims.ts
+++ b/src/store/claims.ts
@@ -33,7 +33,6 @@ import {
   findContractInfo,
   getBlockCycle,
   getDaoStackingStartCycle,
-  getVersionByCycle,
   isMiningClaimEligible,
   isDaoStackingClaimEligible,
   isStackingClaimEligible,
@@ -228,12 +227,13 @@ function getStackingCycleVersion(
   originalVersion: Version,
   cycle: number
 ): Version | null {
-  if (!isDaoVersion(originalVersion)) {
-    const { endCycle } = CITY_CONFIG[city][originalVersion].stacking;
-    if (endCycle !== undefined && cycle > endCycle) return null;
+  if (isDaoVersion(originalVersion)) {
     return originalVersion;
   }
-  return getVersionByCycle(city, cycle) ?? originalVersion;
+
+  const { endCycle } = CITY_CONFIG[city][originalVersion].stacking;
+  if (endCycle !== undefined && cycle > endCycle) return null;
+  return originalVersion;
 }
 
 function getStackingClaimVersion(
@@ -241,10 +241,7 @@ function getStackingClaimVersion(
   originalVersion: Version,
   cycle: number
 ): Version {
-  if (!isDaoVersion(originalVersion)) {
-    return originalVersion;
-  }
-  return getVersionByCycle(city, cycle) ?? originalVersion;
+  return originalVersion;
 }
 
 /**

--- a/src/utilities/contract-reads/dao-stacking.ts
+++ b/src/utilities/contract-reads/dao-stacking.ts
@@ -123,7 +123,7 @@ export interface StackerInfo {
 /**
  * Get stacker info for a user in a specific cycle.
  *
- * Contract function: (get-stacker (city-id uint) (user-id uint) (cycle uint))
+ * Contract function: (get-stacker (city-id uint) (cycle uint) (user-id uint))
  * Returns: (optional { stacked: uint, claimable: uint })
  *
  * @param city - City name (mia or nyc)
@@ -142,7 +142,7 @@ export async function getStacker(
     contractAddress,
     contractName,
     "get-stacker",
-    [uintCV(cityId), uintCV(userId), uintCV(cycle)],
+    [uintCV(cityId), uintCV(cycle), uintCV(userId)],
     contractAddress
   );
 


### PR DESCRIPTION
## Summary
- keep DAO stacking entries on the version/cycle IDs used by the `ccd007-citycoin-stacking` contract instead of remapping them through configured legacy/DAO ranges
- fix the DAO `get-stacker` read argument order to match the live contract ABI
- use the stable paginated table layout for mining and stacking histories so mining no longer renders in the squished virtualized path

## Verification
- `npx vitest run`
- `npm run build`