### PR TITLE
Improve Hiro rate limiting for bulk verification

### DIFF
--- a/src/store/__tests__/verification.test.ts
+++ b/src/store/__tests__/verification.test.ts
@@ -12,6 +12,8 @@
 import { describe, it, expect } from "vitest";
 import type { VerificationStatus, VerificationResult, EntryKey } from "../verification";
 
+const TEST_VERIFICATION_CACHE_FLUSH_SIZE = 10;
+
 // =============================================================================
 // TEST FIXTURES
 // =============================================================================
@@ -58,29 +60,41 @@ function createVerificationResult(
 }
 
 /**
- * Simulate batch cache update (as implemented in verifyAllMiningAtom/verifyAllStackingAtom)
+ * Simulate periodic batch cache updates (as implemented in verifyAllMiningAtom/verifyAllStackingAtom)
  *
- * This simulates collecting results during batch processing and applying once.
+ * This simulates collecting results during batch processing and flushing them
+ * every TEST_VERIFICATION_CACHE_FLUSH_SIZE entries.
  */
-function simulateBatchCacheUpdate(
+function simulatePeriodicBatchCacheUpdate(
   initialCache: Record<string, VerificationResult>,
   entries: Array<{ key: string; status: VerificationStatus; error?: string }>
 ): {
   finalCache: Record<string, VerificationResult>;
   spreadOperations: number;
 } {
-  // Collect all updates
-  const batchUpdates: Record<string, VerificationResult> = {};
+  let cache = initialCache;
+  let batchUpdates: Record<string, VerificationResult> = {};
+  let spreadOperations = 0;
+
+  const flush = () => {
+    if (Object.keys(batchUpdates).length === 0) return;
+    cache = { ...cache, ...batchUpdates };
+    batchUpdates = {};
+    spreadOperations++;
+  };
+
   for (const entry of entries) {
     batchUpdates[entry.key] = createVerificationResult(entry.status, entry.error);
+    if (Object.keys(batchUpdates).length >= TEST_VERIFICATION_CACHE_FLUSH_SIZE) {
+      flush();
+    }
   }
 
-  // Single spread operation to apply all updates
-  const finalCache = { ...initialCache, ...batchUpdates };
+  flush();
 
   return {
-    finalCache,
-    spreadOperations: 1, // Always 1 with batch updates
+    finalCache: cache,
+    spreadOperations,
   };
 }
 
@@ -211,11 +225,10 @@ describe("Cache Key Parsing", () => {
 // =============================================================================
 
 describe("Batch Cache Updates", () => {
-  it("should use constant spread operations regardless of entry count", () => {
+  it("should flush results in bounded batches", () => {
     const initialCache: Record<string, VerificationResult> = {};
 
-    // Simulate 100 entries
-    const entries = Array.from({ length: 100 }, (_, i) => ({
+    const entries = Array.from({ length: 25 }, (_, i) => ({
       key: createCacheKey({
         city: "mia" as const,
         version: "legacyV2" as const,
@@ -225,8 +238,12 @@ describe("Batch Cache Updates", () => {
       status: "claimable" as VerificationStatus,
     }));
 
-    const { spreadOperations } = simulateBatchCacheUpdate(initialCache, entries);
-    expect(spreadOperations).toBe(1);
+    const { finalCache, spreadOperations } = simulatePeriodicBatchCacheUpdate(
+      initialCache,
+      entries
+    );
+    expect(spreadOperations).toBe(3);
+    expect(Object.keys(finalCache)).toHaveLength(25);
   });
 
   it("should produce same final result as per-entry updates", () => {
@@ -240,7 +257,7 @@ describe("Batch Cache Updates", () => {
       { key: "nyc-daoV1-stacking-10", status: "no-reward" as VerificationStatus },
     ];
 
-    const batchResult = simulateBatchCacheUpdate(initialCache, entries);
+    const batchResult = simulatePeriodicBatchCacheUpdate(initialCache, entries);
     const perEntryResult = simulatePerEntryCacheUpdate(initialCache, entries);
 
     // Same keys in final cache
@@ -264,7 +281,7 @@ describe("Batch Cache Updates", () => {
       { key: "mia-legacyV2-mining-200", status: "not-won" as VerificationStatus },
     ];
 
-    const { finalCache } = simulateBatchCacheUpdate(initialCache, entries);
+    const { finalCache } = simulatePeriodicBatchCacheUpdate(initialCache, entries);
 
     // Original entries preserved
     expect(finalCache["mia-legacyV2-mining-100"].status).toBe("claimed");
@@ -283,7 +300,7 @@ describe("Batch Cache Updates", () => {
       { key: "mia-legacyV2-mining-100", status: "claimable" as VerificationStatus },
     ];
 
-    const { finalCache } = simulateBatchCacheUpdate(initialCache, entries);
+    const { finalCache } = simulatePeriodicBatchCacheUpdate(initialCache, entries);
 
     expect(finalCache["mia-legacyV2-mining-100"].status).toBe("claimable");
     expect(finalCache["mia-legacyV2-mining-100"].error).toBeUndefined();
@@ -291,7 +308,7 @@ describe("Batch Cache Updates", () => {
 });
 
 describe("Per-Entry vs Batch Performance Comparison", () => {
-  it("should show O(n) vs O(1) spread operations", () => {
+  it("should show bounded batch writes instead of per-entry writes", () => {
     const initialCache: Record<string, VerificationResult> = {};
     const entryCounts = [10, 50, 100];
 
@@ -301,14 +318,18 @@ describe("Per-Entry vs Batch Performance Comparison", () => {
         status: "claimable" as VerificationStatus,
       }));
 
-      const batchResult = simulateBatchCacheUpdate(initialCache, entries);
+      const batchResult = simulatePeriodicBatchCacheUpdate(initialCache, entries);
       const perEntryResult = simulatePerEntryCacheUpdate(initialCache, entries);
 
-      // Batch always 1
-      expect(batchResult.spreadOperations).toBe(1);
+      expect(batchResult.spreadOperations).toBe(
+        Math.ceil(count / TEST_VERIFICATION_CACHE_FLUSH_SIZE)
+      );
 
       // Per-entry equals count
       expect(perEntryResult.spreadOperations).toBe(count);
+      expect(batchResult.spreadOperations).toBeLessThanOrEqual(
+        perEntryResult.spreadOperations
+      );
     }
   });
 });
@@ -364,10 +385,10 @@ describe("Edge Cases", () => {
       "mia-legacyV2-mining-100": createVerificationResult("claimed"),
     };
 
-    const { finalCache, spreadOperations } = simulateBatchCacheUpdate(initialCache, []);
+    const { finalCache, spreadOperations } = simulatePeriodicBatchCacheUpdate(initialCache, []);
 
     expect(Object.keys(finalCache)).toEqual(Object.keys(initialCache));
-    expect(spreadOperations).toBe(1);
+    expect(spreadOperations).toBe(0);
   });
 
   it("should handle batch update on empty cache", () => {
@@ -375,7 +396,7 @@ describe("Edge Cases", () => {
       { key: "mia-legacyV2-mining-100", status: "claimable" as VerificationStatus },
     ];
 
-    const { finalCache } = simulateBatchCacheUpdate({}, entries);
+    const { finalCache } = simulatePeriodicBatchCacheUpdate({}, entries);
 
     expect(Object.keys(finalCache)).toHaveLength(1);
     expect(finalCache["mia-legacyV2-mining-100"].status).toBe("claimable");
@@ -387,10 +408,10 @@ describe("Edge Cases", () => {
       status: "claimable" as VerificationStatus,
     }));
 
-    const { finalCache, spreadOperations } = simulateBatchCacheUpdate({}, entries);
+    const { finalCache, spreadOperations } = simulatePeriodicBatchCacheUpdate({}, entries);
 
     expect(Object.keys(finalCache)).toHaveLength(1000);
-    expect(spreadOperations).toBe(1);
+    expect(spreadOperations).toBe(100);
   });
 
   it("should handle mixed status batch", () => {
@@ -401,7 +422,7 @@ describe("Edge Cases", () => {
       { key: "mia-legacyV2-mining-103", status: "error" as VerificationStatus, error: "Failed" },
     ];
 
-    const { finalCache } = simulateBatchCacheUpdate({}, entries);
+    const { finalCache } = simulatePeriodicBatchCacheUpdate({}, entries);
 
     expect(finalCache["mia-legacyV2-mining-100"].status).toBe("claimable");
     expect(finalCache["mia-legacyV2-mining-101"].status).toBe("not-won");

--- a/src/store/verification.ts
+++ b/src/store/verification.ts
@@ -28,6 +28,8 @@ import {
   Unsubscribe,
 } from "../utilities/broadcast-sync";
 
+const VERIFICATION_CACHE_FLUSH_SIZE = 10;
+
 // =============================================================================
 // TYPES
 // =============================================================================
@@ -422,9 +424,9 @@ export const verifySingleMiningAtom = atom(
 /**
  * Verify all unverified mining entries for a city
  *
- * Uses batch cache updates: collects all verification results during processing,
- * then applies a single cache update at the end. This reduces complexity from
- * O(n*k) to O(n+k) where n = entries to verify, k = cache size.
+ * Uses periodic batch cache updates: collects verification results during
+ * processing, then flushes them in small groups so long runs survive refreshes
+ * without writing the full cache after every request.
  *
  * Note: "verifying" status is still set per-entry for UI feedback during long operations.
  */
@@ -462,8 +464,16 @@ export const verifyAllMiningAtom = atom(
       currentItem: "",
     });
 
-    // Collect all verification results for batch cache update
-    const batchUpdates: Record<string, VerificationResult> = {};
+    // Collect verification results for periodic batch cache updates.
+    let batchUpdates: Record<string, VerificationResult> = {};
+
+    const flushBatchUpdates = () => {
+      if (Object.keys(batchUpdates).length === 0) return;
+
+      const currentCache = get(verificationCacheAtom);
+      set(verificationCacheAtom, { ...currentCache, ...batchUpdates });
+      batchUpdates = {};
+    };
 
     // Process entries one by one (rate limited by hiroFetch)
     for (let i = 0; i < unverified.length; i++) {
@@ -514,11 +524,14 @@ export const verifyAllMiningAtom = atom(
           error: error instanceof Error ? error.message : String(error),
         };
       }
+
+      if (Object.keys(batchUpdates).length >= VERIFICATION_CACHE_FLUSH_SIZE) {
+        flushBatchUpdates();
+      }
     }
 
-    // Apply all results in a single batch cache update - O(k) instead of O(n*k)
-    const finalCache = get(verificationCacheAtom);
-    set(verificationCacheAtom, { ...finalCache, ...batchUpdates });
+    // Persist any remaining results so long verification runs survive refreshes.
+    flushBatchUpdates();
 
     set(verificationProgressAtom, {
       isRunning: false,
@@ -626,9 +639,9 @@ export const verifySingleStackingAtom = atom(
 /**
  * Verify all unverified stacking entries for a city
  *
- * Uses batch cache updates: collects all verification results during processing,
- * then applies a single cache update at the end. This reduces complexity from
- * O(n*k) to O(n+k) where n = entries to verify, k = cache size.
+ * Uses periodic batch cache updates: collects verification results during
+ * processing, then flushes them in small groups so long runs survive refreshes
+ * without writing the full cache after every request.
  *
  * Note: "verifying" status is still set per-entry for UI feedback during long operations.
  */
@@ -671,8 +684,16 @@ export const verifyAllStackingAtom = atom(
       currentItem: "",
     });
 
-    // Collect all verification results for batch cache update
-    const batchUpdates: Record<string, VerificationResult> = {};
+    // Collect verification results for periodic batch cache updates.
+    let batchUpdates: Record<string, VerificationResult> = {};
+
+    const flushBatchUpdates = () => {
+      if (Object.keys(batchUpdates).length === 0) return;
+
+      const currentCache = get(verificationCacheAtom);
+      set(verificationCacheAtom, { ...currentCache, ...batchUpdates });
+      batchUpdates = {};
+    };
 
     // Process entries one by one (rate limited by hiroFetch)
     for (let i = 0; i < unverified.length; i++) {
@@ -724,11 +745,14 @@ export const verifyAllStackingAtom = atom(
           error: error instanceof Error ? error.message : String(error),
         };
       }
+
+      if (Object.keys(batchUpdates).length >= VERIFICATION_CACHE_FLUSH_SIZE) {
+        flushBatchUpdates();
+      }
     }
 
-    // Apply all results in a single batch cache update - O(k) instead of O(n*k)
-    const finalCache = get(verificationCacheAtom);
-    set(verificationCacheAtom, { ...finalCache, ...batchUpdates });
+    // Persist any remaining results so long verification runs survive refreshes.
+    flushBatchUpdates();
 
     set(verificationProgressAtom, {
       isRunning: false,

--- a/src/utilities/hiro-client.ts
+++ b/src/utilities/hiro-client.ts
@@ -25,7 +25,10 @@ const HIRO_API_BASE = "https://api.hiro.so";
 const DEFAULT_DELAY_MS = 200;
 const MIN_DELAY_MS = 50;
 const SLOW_DELAY_MS = 500;
-const MAX_DELAY_MS = 2000; // Cap to prevent unbounded delays
+const CONTRACT_READ_DELAY_MS = 1100;
+const MAX_NORMAL_DELAY_MS = 5000;
+const MAX_RATE_LIMIT_DELAY_MS = 65000;
+const RATE_LIMIT_BUFFER_MS = 500;
 
 // =============================================================================
 // RATE LIMIT STATE
@@ -34,7 +37,8 @@ const MAX_DELAY_MS = 2000; // Cap to prevent unbounded delays
 interface RateLimitState {
   remainingSecond: number | null;
   remainingMinute: number | null;
-  reset: number | null;
+  resetAt: number | null;
+  cooldownUntil: number | null;
   cost: number | null;
   lastRequest: number;
 }
@@ -42,7 +46,8 @@ interface RateLimitState {
 const state: RateLimitState = {
   remainingSecond: null,
   remainingMinute: null,
-  reset: null,
+  resetAt: null,
+  cooldownUntil: null,
   cost: null,
   lastRequest: 0,
 };
@@ -57,6 +62,33 @@ function safeParseInt(value: string | null): number | null {
 }
 
 /**
+ * Parse rate limit reset headers into an absolute timestamp.
+ *
+ * Hiro may return a relative second count or an epoch timestamp depending on
+ * the gateway. This accepts both forms so we can avoid retrying during a known
+ * exhausted window.
+ */
+function parseResetAt(value: string | null): number | null {
+  if (!value) return null;
+
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return null;
+
+  if (parsed > 1_000_000_000_000) {
+    return parsed;
+  }
+  if (parsed > 1_000_000_000) {
+    return parsed * 1000;
+  }
+  return Date.now() + parsed * 1000;
+}
+
+function getResetDelay(): number | null {
+  if (!state.resetAt) return null;
+  return Math.max(0, state.resetAt - Date.now() + RATE_LIMIT_BUFFER_MS);
+}
+
+/**
  * Update rate limit state from response headers
  */
 function updateRateLimitState(headers: Headers): void {
@@ -66,7 +98,7 @@ function updateRateLimitState(headers: Headers): void {
   state.remainingMinute = safeParseInt(
     headers.get("x-ratelimit-remaining-stacks-minute")
   );
-  state.reset = safeParseInt(headers.get("ratelimit-reset"));
+  state.resetAt = parseResetAt(headers.get("ratelimit-reset"));
   state.cost = safeParseInt(headers.get("x-ratelimit-cost-stacks"));
   state.lastRequest = Date.now();
 }
@@ -74,28 +106,59 @@ function updateRateLimitState(headers: Headers): void {
 /**
  * Calculate delay before next request based on rate limit state
  */
-function calculateDelay(): number {
+function calculateDelay(minDelayMs = MIN_DELAY_MS): number {
+  if (state.cooldownUntil !== null) {
+    const cooldownDelay = state.cooldownUntil - Date.now();
+    if (cooldownDelay > 0) {
+      return Math.min(MAX_RATE_LIMIT_DELAY_MS, cooldownDelay);
+    }
+    state.cooldownUntil = null;
+  }
+
   // If we have no state, use conservative default
   if (state.remainingSecond === null && state.remainingMinute === null) {
-    return DEFAULT_DELAY_MS;
+    return Math.max(DEFAULT_DELAY_MS, minDelayMs);
   }
 
   // If per-second quota is exhausted, wait until next second
   if (state.remainingSecond !== null && state.remainingSecond <= 0) {
     const elapsed = Date.now() - state.lastRequest;
-    return Math.min(MAX_DELAY_MS, Math.max(0, 1000 - elapsed));
+    return Math.min(
+      MAX_RATE_LIMIT_DELAY_MS,
+      Math.max(minDelayMs, 1000 - elapsed)
+    );
   }
 
-  // If per-minute quota is low or exhausted, slow down proportionally
-  if (state.remainingMinute !== null && state.remainingMinute < 10) {
-    // When minute quota is low, spread remaining requests across time
-    // Lower quota = longer delay, but cap at MAX_DELAY_MS
-    const quotaDelay = Math.max(0, 10 - state.remainingMinute) * 100;
-    return Math.min(MAX_DELAY_MS, SLOW_DELAY_MS + quotaDelay);
+  if (state.remainingMinute !== null && state.remainingMinute <= 0) {
+    const resetDelay = getResetDelay() ?? 60_000;
+    return Math.min(MAX_RATE_LIMIT_DELAY_MS, Math.max(minDelayMs, resetDelay));
+  }
+
+  // If per-minute quota is getting low, spread remaining requests across the
+  // current reset window instead of waiting until the bucket is empty.
+  if (state.remainingMinute !== null && state.remainingMinute < 25) {
+    const resetDelay = getResetDelay();
+    if (resetDelay !== null) {
+      const spreadDelay = Math.ceil(
+        resetDelay / Math.max(1, state.remainingMinute)
+      );
+      return Math.min(
+        MAX_RATE_LIMIT_DELAY_MS,
+        Math.max(minDelayMs, spreadDelay)
+      );
+    }
+
+    return Math.min(
+      MAX_NORMAL_DELAY_MS,
+      Math.max(
+        minDelayMs,
+        SLOW_DELAY_MS + Math.max(0, 25 - state.remainingMinute) * 200
+      )
+    );
   }
 
   // Otherwise use minimal delay
-  return MIN_DELAY_MS;
+  return minDelayMs;
 }
 
 // =============================================================================
@@ -103,7 +166,8 @@ function calculateDelay(): number {
 // =============================================================================
 
 interface QueuedRequest {
-  resolve: () => void;
+  run: () => Promise<void>;
+  minDelayMs: number;
 }
 
 class HiroRequestQueue {
@@ -111,9 +175,18 @@ class HiroRequestQueue {
   private processing = false;
   private processingPromise: Promise<void> | null = null;
 
-  async waitForTurn(): Promise<void> {
-    return new Promise((resolve) => {
-      this.queue.push({ resolve });
+  async run<T>(minDelayMs: number, task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.queue.push({
+        minDelayMs,
+        run: async () => {
+          try {
+            resolve(await task());
+          } catch (error) {
+            reject(error);
+          }
+        },
+      });
       this.startProcessing();
     });
   }
@@ -131,7 +204,10 @@ class HiroRequestQueue {
 
   private async processQueue(): Promise<void> {
     while (this.queue.length > 0) {
-      const delay = calculateDelay();
+      const next = this.queue.shift();
+      if (!next) continue;
+
+      const delay = calculateDelay(next.minDelayMs);
       if (delay > 0) {
         await sleep(delay);
       }
@@ -139,8 +215,7 @@ class HiroRequestQueue {
       // Update lastRequest timestamp when request is allowed to proceed
       state.lastRequest = Date.now();
 
-      const next = this.queue.shift();
-      next?.resolve();
+      await next.run();
     }
   }
 
@@ -169,7 +244,8 @@ export function resetHiroClientForTesting(): void {
   hiroQueue.reset();
   state.remainingSecond = null;
   state.remainingMinute = null;
-  state.reset = null;
+  state.resetAt = null;
+  state.cooldownUntil = null;
   state.cost = null;
   state.lastRequest = 0;
 }
@@ -214,6 +290,7 @@ export interface HiroClientResult<T> {
 
 export interface HiroClientOptions {
   maxRetries?: number;
+  minDelayMs?: number;
 }
 
 // =============================================================================
@@ -227,61 +304,66 @@ export async function hiroFetch<T = unknown>(
   url: string,
   options: HiroClientOptions & RequestInit = {}
 ): Promise<HiroClientResult<T>> {
-  const { maxRetries = 3, ...fetchOptions } = options;
+  const { maxRetries = 3, minDelayMs = MIN_DELAY_MS, ...fetchOptions } = options;
 
-  for (let attempt = 0; attempt <= maxRetries; attempt++) {
-    await hiroQueue.waitForTurn();
+  return hiroQueue.run(minDelayMs, async () => {
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        const response = await fetch(url, fetchOptions);
 
-    try {
-      const response = await fetch(url, fetchOptions);
+        // Update rate limit state from headers
+        updateRateLimitState(response.headers);
 
-      // Update rate limit state from headers
-      updateRateLimitState(response.headers);
+        // Handle rate limiting
+        if (response.status === 429) {
+          const retryAfter = parseRetryAfter(response.headers.get("Retry-After"));
+          const resetDelay = getResetDelay();
+          const waitMs = Math.min(
+            MAX_RATE_LIMIT_DELAY_MS,
+            retryAfter ?? resetDelay ?? 1000 * Math.pow(2, attempt + 1)
+          );
+          state.cooldownUntil = Date.now() + waitMs;
+          await sleep(waitMs);
+          continue;
+        }
 
-      // Handle rate limiting
-      if (response.status === 429) {
-        const retryAfter = parseRetryAfter(response.headers.get("Retry-After"));
-        const waitMs = retryAfter || 1000 * Math.pow(2, attempt + 1);
-        await sleep(waitMs);
-        continue;
-      }
+        // Handle non-OK responses
+        if (!response.ok) {
+          return {
+            ok: false,
+            status: response.status,
+            error: `HTTP ${response.status}: ${response.statusText}`,
+          };
+        }
 
-      // Handle non-OK responses
-      if (!response.ok) {
+        // Parse JSON response
+        const data = await response.json();
+
         return {
-          ok: false,
+          ok: true,
           status: response.status,
-          error: `HTTP ${response.status}: ${response.statusText}`,
+          data: data as T,
         };
+      } catch (error) {
+        if (attempt === maxRetries) {
+          return {
+            ok: false,
+            status: 0,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
+
+        const waitMs = 1000 * Math.pow(2, attempt);
+        await sleep(waitMs);
       }
-
-      // Parse JSON response
-      const data = await response.json();
-
-      return {
-        ok: true,
-        status: response.status,
-        data: data as T,
-      };
-    } catch (error) {
-      if (attempt === maxRetries) {
-        return {
-          ok: false,
-          status: 0,
-          error: error instanceof Error ? error.message : String(error),
-        };
-      }
-
-      const waitMs = 1000 * Math.pow(2, attempt);
-      await sleep(waitMs);
     }
-  }
 
-  return {
-    ok: false,
-    status: 0,
-    error: `Max retries (${maxRetries}) exceeded for ${url}`,
-  };
+    return {
+      ok: false,
+      status: 0,
+      error: `Max retries (${maxRetries}) exceeded for ${url}`,
+    };
+  });
 }
 
 // =============================================================================
@@ -332,6 +414,7 @@ export async function callReadOnlyFunction<T = string>(
 
   const result = await hiroFetch<ReadOnlyResponse>(url, {
     method: "POST",
+    minDelayMs: CONTRACT_READ_DELAY_MS,
     headers: {
       "Content-Type": "application/json",
     },


### PR DESCRIPTION
## Summary
- apply a slower baseline delay to Hiro read-only contract calls used by claim verification
- honor rate-limit reset windows and share cooldowns after 429 responses so queued requests do not continue hammering the API
- flush mining and stacking verification cache updates every 10 completed entries so long runs persist partial progress

## Verification
- `npx vitest run`
- `npm run build`