### PR TITLE
Fix DAO claim city argument serialization

### DIFF
--- a/src/utilities/__tests__/claim-transactions.test.ts
+++ b/src/utilities/__tests__/claim-transactions.test.ts
@@ -1,8 +1,25 @@
 import { describe, expect, it } from "vitest";
-import { buildStackingClaimTx } from "../claim-transactions";
+import { deserializeCV } from "@stacks/transactions";
+import { Buffer } from "buffer";
+import { buildMiningClaimTx, buildStackingClaimTx } from "../claim-transactions";
 import { CITY_CONFIG } from "../../config/city-config";
 
+function deserializeArg(hex: string) {
+  return deserializeCV(Buffer.from(hex.replace(/^0x/, ""), "hex"));
+}
+
 describe("claim transaction builders", () => {
+  describe("buildMiningClaimTx", () => {
+    it("serializes DAO city names as string-ascii", () => {
+      const params = buildMiningClaimTx("mia", "daoV2", 109489);
+
+      expect(deserializeArg(params.functionArgs[0])).toEqual({
+        type: "ascii",
+        value: "mia",
+      });
+    });
+  });
+
   describe("buildStackingClaimTx", () => {
     it("rejects cycles after the final DAO stacking cycle", () => {
       expect(() => buildStackingClaimTx("mia", "daoV2", 93)).toThrow(
@@ -19,6 +36,10 @@ describe("claim transaction builders", () => {
       expect(params.contract).toBe(CITY_CONFIG.mia.daoV2.stacking.contractId);
       expect(params.functionName).toBe("claim-stacking-reward");
       expect(params.functionArgs).toHaveLength(2);
+      expect(deserializeArg(params.functionArgs[0])).toEqual({
+        type: "ascii",
+        value: "mia",
+      });
     });
 
     it("normalizes shared DAO stacking claims to the cycle's DAO version", () => {

--- a/src/utilities/claim-transactions.ts
+++ b/src/utilities/claim-transactions.ts
@@ -46,8 +46,8 @@ export function buildMiningClaimTx(
   let functionArgs: string[];
 
   if (isDao) {
-    // DAO: (cityName: (string-utf8 10), claimHeight: uint)
-    const cityArg = Cl.stringUtf8(city);
+    // DAO: (cityName: (string-ascii 10), claimHeight: uint)
+    const cityArg = Cl.stringAscii(city);
     const blockArg = Cl.uint(blockHeight);
     functionArgs = [Cl.serialize(cityArg), Cl.serialize(blockArg)];
   } else {
@@ -98,8 +98,8 @@ export function buildStackingClaimTx(
   let functionArgs: string[];
 
   if (isDao) {
-    // DAO: (cityName: (string-utf8 10), targetCycle: uint)
-    const cityArg = Cl.stringUtf8(city);
+    // DAO: (cityName: (string-ascii 10), targetCycle: uint)
+    const cityArg = Cl.stringAscii(city);
     const cycleArg = Cl.uint(cycle);
     functionArgs = [Cl.serialize(cityArg), Cl.serialize(cycleArg)];
   } else {


### PR DESCRIPTION
## Summary
- serialize DAO claim city names as Clarity string-ascii instead of string-utf8
- add regression tests that deserialize built claim args and verify the Clarity type

## Testing
- npx vitest run src/utilities/__tests__/claim-transactions.test.ts
- npm run build