### PR TITLE
Add stacked token recovery checks

### DIFF
--- a/src/components/tabs/mia.tsx
+++ b/src/components/tabs/mia.tsx
@@ -48,6 +48,11 @@ import {
   stackingVerificationSummaryAtom,
 } from "../../store/verification";
 import {
+  checkStackingRecoveryAtom,
+  miaStackingRecoveryEntriesAtom,
+  miaStackingRecoveryStatusAtom,
+} from "../../store/stacking-recovery";
+import {
   buildMiningClaimTx,
   buildStackingClaimTx,
   executeClaimTransaction,
@@ -116,6 +121,8 @@ function Mia() {
   const stackingEntries = useAtomValue(miaStackingEntriesAtom);
   const unclaimedMining = useAtomValue(miaUnclaimedMiningAtom);
   const unclaimedStacking = useAtomValue(miaUnclaimedStackingAtom);
+  const stackingRecoveryEntries = useAtomValue(miaStackingRecoveryEntriesAtom);
+  const stackingRecoveryStatus = useAtomValue(miaStackingRecoveryStatusAtom);
 
   // Entries needing verification
   const miningNeedingVerification = useAtomValue(miningEntriesNeedingVerificationAtom);
@@ -128,6 +135,7 @@ function Mia() {
   const verifySingleStacking = useSetAtom(verifySingleStackingAtom);
   const retryFailedMining = useSetAtom(retryFailedMiningAtom);
   const retryFailedStacking = useSetAtom(retryFailedStackingAtom);
+  const checkStackingRecovery = useSetAtom(checkStackingRecoveryAtom);
 
   // Verification progress and summaries
   const verificationProgress = useAtomValue(verificationProgressAtom);
@@ -143,6 +151,16 @@ function Mia() {
     () => getStackingVerificationSummary(stackingEntries),
     [getStackingVerificationSummary, stackingEntries]
   );
+  const visibleUnclaimedStacking = useMemo(() => {
+    const recoveryKeys = new Set(
+      stackingRecoveryEntries.map((entry) => `${entry.city}-${entry.version}-${entry.cycle}`)
+    );
+    return unclaimedStacking.filter((entry) => {
+      return !recoveryKeys.has(`${entry.city}-${entry.version}-${entry.cycle}`);
+    });
+  }, [stackingRecoveryEntries, unclaimedStacking]);
+  const unclaimedFundsCount =
+    unclaimedMining.length + visibleUnclaimedStacking.length + stackingRecoveryEntries.length;
 
   // Redemption state
   const [redemptionInfo, setRedemptionInfo] = useState<Ccd013RedemptionInfo | null>(null);
@@ -220,6 +238,10 @@ function Mia() {
   const handleVerifyStacking = useCallback((entry: StackingEntry) => {
     verifySingleStacking(entry);
   }, [verifySingleStacking]);
+
+  const handleCheckStackingRecovery = useCallback(() => {
+    checkStackingRecovery(config.cityName);
+  }, [checkStackingRecovery]);
 
   const loadRedemptionPreview = useCallback(async () => {
     if (!stxAddress) return;
@@ -386,16 +408,39 @@ function Mia() {
           <Accordion.ItemTrigger>
             <Heading size="xl">
               Unclaimed Funds
-              {(unclaimedMining.length > 0 || unclaimedStacking.length > 0) && (
+              {unclaimedFundsCount > 0 && (
                 <Badge colorPalette="green" ml={2}>
-                  {unclaimedMining.length + unclaimedStacking.length}
+                  {unclaimedFundsCount}
                 </Badge>
               )}
             </Heading>
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
           <Accordion.ItemContent p={4}>
-            {unclaimedMining.length === 0 && unclaimedStacking.length === 0 ? (
+            <Stack gap={3} mb={4}>
+              <HStack gap={3} align="center">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCheckStackingRecovery}
+                  disabled={stackingRecoveryStatus.isChecking || !userIds}
+                >
+                  {stackingRecoveryStatus.isChecking ? "Checking..." : `Check ${config.symbol} Recovery`}
+                </Button>
+                {stackingRecoveryStatus.checkedAt && (
+                  <Text fontSize="sm" color="fg.muted">
+                    {stackingRecoveryEntries.length > 0
+                      ? `${stackingRecoveryEntries.length} recovery claim found`
+                      : "No stacked token recovery found"}
+                  </Text>
+                )}
+              </HStack>
+              {stackingRecoveryStatus.error && (
+                <Text fontSize="sm" color="red.500">{stackingRecoveryStatus.error}</Text>
+              )}
+            </Stack>
+
+            {unclaimedMining.length === 0 && visibleUnclaimedStacking.length === 0 && stackingRecoveryEntries.length === 0 ? (
               <Stack gap={4}>
                 <Text color="fg.muted">No verified claimable funds yet.</Text>
                 {(cityUnverifiedMining > 0 || cityUnverifiedStacking > 0) && (
@@ -445,10 +490,48 @@ function Mia() {
                   </Box>
                 )}
 
-                {/* Unclaimed Stacking */}
-                {unclaimedStacking.length > 0 && (
+                {/* Stacked Token Recovery */}
+                {stackingRecoveryEntries.length > 0 && (
                   <Box>
-                    <Heading size="md" mb={2}>Stacking Rewards ({unclaimedStacking.length})</Heading>
+                    <Heading size="md" mb={2}>Stacked Token Recovery ({stackingRecoveryEntries.length})</Heading>
+                    <Text fontSize="sm" color="fg.muted" mb={2}>
+                      Recover {config.symbol} principal still held in finished stacking contracts.
+                    </Text>
+                    <Table.Root size="sm" width="100%">
+                      <Table.Header>
+                        <Table.Row>
+                          <Table.ColumnHeader>Cycle</Table.ColumnHeader>
+                          <Table.ColumnHeader>Version</Table.ColumnHeader>
+                          <Table.ColumnHeader>Recoverable</Table.ColumnHeader>
+                          <Table.ColumnHeader>Action</Table.ColumnHeader>
+                        </Table.Row>
+                      </Table.Header>
+                      <Table.Body>
+                        {stackingRecoveryEntries.map((entry) => (
+                          <Table.Row key={`${entry.txId}-${entry.cycle}`}>
+                            <Table.Cell>{entry.cycle}</Table.Cell>
+                            <Table.Cell>{entry.version}</Table.Cell>
+                            <Table.Cell>{formatStackedAmount(entry.amountTokens, entry.version)}</Table.Cell>
+                            <Table.Cell>
+                              <Button
+                                size="xs"
+                                onClick={() => handleStackingClaim(entry)}
+                                disabled={claimingId === `stacking-${entry.cycle}`}
+                              >
+                                {claimingId === `stacking-${entry.cycle}` ? "Claiming..." : "Recover"}
+                              </Button>
+                            </Table.Cell>
+                          </Table.Row>
+                        ))}
+                      </Table.Body>
+                    </Table.Root>
+                  </Box>
+                )}
+
+                {/* Unclaimed Stacking */}
+                {visibleUnclaimedStacking.length > 0 && (
+                  <Box>
+                    <Heading size="md" mb={2}>Stacking Rewards ({visibleUnclaimedStacking.length})</Heading>
                     <Text fontSize="sm" color="fg.muted" mb={2}>
                       Claim STX rewards for cycles you stacked. Final cycle also returns your {config.symbol}.
                     </Text>
@@ -462,7 +545,7 @@ function Mia() {
                         </Table.Row>
                       </Table.Header>
                       <Table.Body>
-                        {unclaimedStacking.map((entry) => (
+                        {visibleUnclaimedStacking.map((entry) => (
                           <Table.Row key={`${entry.txId}-${entry.cycle}`}>
                             <Table.Cell>{entry.cycle}</Table.Cell>
                             <Table.Cell>{entry.version}</Table.Cell>

--- a/src/components/tabs/nyc.tsx
+++ b/src/components/tabs/nyc.tsx
@@ -47,6 +47,11 @@ import {
   stackingVerificationSummaryAtom,
 } from "../../store/verification";
 import {
+  checkStackingRecoveryAtom,
+  nycStackingRecoveryEntriesAtom,
+  nycStackingRecoveryStatusAtom,
+} from "../../store/stacking-recovery";
+import {
   buildMiningClaimTx,
   buildStackingClaimTx,
   executeClaimTransaction,
@@ -78,6 +83,8 @@ function Nyc() {
   const stackingEntries = useAtomValue(nycStackingEntriesAtom);
   const unclaimedMining = useAtomValue(nycUnclaimedMiningAtom);
   const unclaimedStacking = useAtomValue(nycUnclaimedStackingAtom);
+  const stackingRecoveryEntries = useAtomValue(nycStackingRecoveryEntriesAtom);
+  const stackingRecoveryStatus = useAtomValue(nycStackingRecoveryStatusAtom);
 
   // Entries needing verification
   const miningNeedingVerification = useAtomValue(miningEntriesNeedingVerificationAtom);
@@ -90,6 +97,7 @@ function Nyc() {
   const verifySingleStacking = useSetAtom(verifySingleStackingAtom);
   const retryFailedMining = useSetAtom(retryFailedMiningAtom);
   const retryFailedStacking = useSetAtom(retryFailedStackingAtom);
+  const checkStackingRecovery = useSetAtom(checkStackingRecoveryAtom);
 
   // Verification progress and summaries
   const verificationProgress = useAtomValue(verificationProgressAtom);
@@ -105,6 +113,16 @@ function Nyc() {
     () => getStackingVerificationSummary(stackingEntries),
     [getStackingVerificationSummary, stackingEntries]
   );
+  const visibleUnclaimedStacking = useMemo(() => {
+    const recoveryKeys = new Set(
+      stackingRecoveryEntries.map((entry) => `${entry.city}-${entry.version}-${entry.cycle}`)
+    );
+    return unclaimedStacking.filter((entry) => {
+      return !recoveryKeys.has(`${entry.city}-${entry.version}-${entry.cycle}`);
+    });
+  }, [stackingRecoveryEntries, unclaimedStacking]);
+  const unclaimedFundsCount =
+    unclaimedMining.length + visibleUnclaimedStacking.length + stackingRecoveryEntries.length;
 
   // Redemption state
   const [hasChecked, setHasChecked] = useState(false);
@@ -181,6 +199,10 @@ function Nyc() {
   const handleVerifyStacking = useCallback((entry: StackingEntry) => {
     verifySingleStacking(entry);
   }, [verifySingleStacking]);
+
+  const handleCheckStackingRecovery = useCallback(() => {
+    checkStackingRecovery(config.cityName);
+  }, [checkStackingRecovery]);
 
   if (!stxAddress) {
     return (
@@ -313,16 +335,39 @@ function Nyc() {
           <Accordion.ItemTrigger>
             <Heading size="xl">
               Unclaimed Funds
-              {(unclaimedMining.length > 0 || unclaimedStacking.length > 0) && (
+              {unclaimedFundsCount > 0 && (
                 <Badge colorPalette="green" ml={2}>
-                  {unclaimedMining.length + unclaimedStacking.length}
+                  {unclaimedFundsCount}
                 </Badge>
               )}
             </Heading>
             <Accordion.ItemIndicator />
           </Accordion.ItemTrigger>
           <Accordion.ItemContent p={4}>
-            {unclaimedMining.length === 0 && unclaimedStacking.length === 0 ? (
+            <Stack gap={3} mb={4}>
+              <HStack gap={3} align="center">
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCheckStackingRecovery}
+                  disabled={stackingRecoveryStatus.isChecking || !userIds}
+                >
+                  {stackingRecoveryStatus.isChecking ? "Checking..." : `Check ${config.symbol} Recovery`}
+                </Button>
+                {stackingRecoveryStatus.checkedAt && (
+                  <Text fontSize="sm" color="fg.muted">
+                    {stackingRecoveryEntries.length > 0
+                      ? `${stackingRecoveryEntries.length} recovery claim found`
+                      : "No stacked token recovery found"}
+                  </Text>
+                )}
+              </HStack>
+              {stackingRecoveryStatus.error && (
+                <Text fontSize="sm" color="red.500">{stackingRecoveryStatus.error}</Text>
+              )}
+            </Stack>
+
+            {unclaimedMining.length === 0 && visibleUnclaimedStacking.length === 0 && stackingRecoveryEntries.length === 0 ? (
               <Stack gap={4}>
                 <Text color="fg.muted">No verified claimable funds yet.</Text>
                 {(cityUnverifiedMining > 0 || cityUnverifiedStacking > 0) && (
@@ -372,10 +417,48 @@ function Nyc() {
                   </Box>
                 )}
 
-                {/* Unclaimed Stacking */}
-                {unclaimedStacking.length > 0 && (
+                {/* Stacked Token Recovery */}
+                {stackingRecoveryEntries.length > 0 && (
                   <Box>
-                    <Heading size="md" mb={2}>Stacking Rewards ({unclaimedStacking.length})</Heading>
+                    <Heading size="md" mb={2}>Stacked Token Recovery ({stackingRecoveryEntries.length})</Heading>
+                    <Text fontSize="sm" color="fg.muted" mb={2}>
+                      Recover {config.symbol} principal still held in finished stacking contracts.
+                    </Text>
+                    <Table.Root size="sm" width="100%">
+                      <Table.Header>
+                        <Table.Row>
+                          <Table.ColumnHeader>Cycle</Table.ColumnHeader>
+                          <Table.ColumnHeader>Version</Table.ColumnHeader>
+                          <Table.ColumnHeader>Recoverable</Table.ColumnHeader>
+                          <Table.ColumnHeader>Action</Table.ColumnHeader>
+                        </Table.Row>
+                      </Table.Header>
+                      <Table.Body>
+                        {stackingRecoveryEntries.map((entry) => (
+                          <Table.Row key={`${entry.txId}-${entry.cycle}`}>
+                            <Table.Cell>{entry.cycle}</Table.Cell>
+                            <Table.Cell>{entry.version}</Table.Cell>
+                            <Table.Cell>{formatStackedAmount(entry.amountTokens, entry.version)}</Table.Cell>
+                            <Table.Cell>
+                              <Button
+                                size="xs"
+                                onClick={() => handleStackingClaim(entry)}
+                                disabled={claimingId === `stacking-${entry.cycle}`}
+                              >
+                                {claimingId === `stacking-${entry.cycle}` ? "Claiming..." : "Recover"}
+                              </Button>
+                            </Table.Cell>
+                          </Table.Row>
+                        ))}
+                      </Table.Body>
+                    </Table.Root>
+                  </Box>
+                )}
+
+                {/* Unclaimed Stacking */}
+                {visibleUnclaimedStacking.length > 0 && (
+                  <Box>
+                    <Heading size="md" mb={2}>Stacking Rewards ({visibleUnclaimedStacking.length})</Heading>
                     <Text fontSize="sm" color="fg.muted" mb={2}>
                       Claim STX rewards for cycles you stacked. Final cycle also returns your {config.symbol}.
                     </Text>
@@ -389,7 +472,7 @@ function Nyc() {
                         </Table.Row>
                       </Table.Header>
                       <Table.Body>
-                        {unclaimedStacking.map((entry) => (
+                        {visibleUnclaimedStacking.map((entry) => (
                           <Table.Row key={`${entry.txId}-${entry.cycle}`}>
                             <Table.Cell>{entry.cycle}</Table.Cell>
                             <Table.Cell>{entry.version}</Table.Cell>

--- a/src/store/__tests__/stacking-recovery.test.ts
+++ b/src/store/__tests__/stacking-recovery.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createStore } from "jotai";
+import { stxAddressAtom, userIdsAtom } from "../stacks";
+import {
+  checkStackingRecoveryAtom,
+  miaStackingRecoveryEntriesAtom,
+  miaStackingRecoveryStatusAtom,
+  nycStackingRecoveryEntriesAtom,
+} from "../stacking-recovery";
+import {
+  daoGetStacker,
+  legacyGetStackerAtCycle,
+} from "../../utilities/contract-reads";
+
+vi.mock("../../utilities/contract-reads", () => ({
+  daoGetStacker: vi.fn(),
+  legacyGetStackerAtCycle: vi.fn(),
+}));
+
+const mockDaoGetStacker = vi.mocked(daoGetStacker);
+const mockLegacyGetStackerAtCycle = vi.mocked(legacyGetStackerAtCycle);
+
+const TEST_ADDRESS = "SPP90JN2DSY4PHMKG613G3163A5VEQSN2KB2FAHP";
+
+function setupStore(address = TEST_ADDRESS) {
+  const store = createStore();
+  store.set(stxAddressAtom, address);
+  store.set(userIdsAtom, {
+    legacy: {
+      mia: { v1: 11, v2: 12 },
+      nyc: { v1: 21, v2: 22 },
+    },
+    dao: 1,
+  });
+  return store;
+}
+
+describe("stacking recovery atoms", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLegacyGetStackerAtCycle.mockResolvedValue({
+      ok: true,
+      data: { amountStacked: 0, toReturn: 0 },
+    });
+    mockDaoGetStacker.mockResolvedValue({
+      ok: true,
+      data: { stacked: 0, claimable: 0 },
+    });
+  });
+
+  it("creates recovery entries from final-cycle legacy toReturn and DAO claimable state", async () => {
+    const store = setupStore();
+
+    mockLegacyGetStackerAtCycle.mockImplementation(async (_city, version, _userId, cycle) => {
+      return {
+        ok: true,
+        data: {
+          amountStacked: 0,
+          toReturn: version === "legacyV2" && cycle === 34 ? 208_000_000_000 : 0,
+        },
+      };
+    });
+    mockDaoGetStacker.mockImplementation(async (_city, _userId, cycle) => {
+      return {
+        ok: true,
+        data: {
+          stacked: 444_375_000_000,
+          claimable: cycle === 85 ? 444_375_000_000 : 0,
+        },
+      };
+    });
+
+    await store.set(checkStackingRecoveryAtom, "mia");
+
+    expect(mockLegacyGetStackerAtCycle).toHaveBeenCalledWith("mia", "legacyV1", 11, 15);
+    expect(mockLegacyGetStackerAtCycle).toHaveBeenCalledWith("mia", "legacyV1", 11, 16);
+    expect(mockLegacyGetStackerAtCycle).toHaveBeenCalledWith("mia", "legacyV2", 12, 33);
+    expect(mockLegacyGetStackerAtCycle).toHaveBeenCalledWith("mia", "legacyV2", 12, 34);
+    expect(mockDaoGetStacker).toHaveBeenCalledWith("mia", 1, 53);
+    expect(mockDaoGetStacker).toHaveBeenCalledWith("mia", 1, 85);
+    expect(mockDaoGetStacker).toHaveBeenCalledWith("mia", 1, 86);
+
+    const entries = store.get(miaStackingRecoveryEntriesAtom);
+    expect(entries).toHaveLength(2);
+    expect(entries.map((entry) => `${entry.version}-${entry.cycle}`)).toEqual([
+      "legacyV2-34",
+      "daoV2-85",
+    ]);
+    expect(entries[0]).toMatchObject({
+      city: "mia",
+      version: "legacyV2",
+      cycle: 34,
+      functionName: "claim-stacking-reward",
+      status: "claimable",
+      isRecovery: true,
+    });
+    expect(entries[0].amountTokens).toBe(208_000_000_000n);
+    expect(entries[1].amountTokens).toBe(444_375_000_000n);
+
+    expect(store.get(miaStackingRecoveryStatusAtom)).toMatchObject({
+      isChecking: false,
+      error: null,
+    });
+  });
+
+  it("stores errors in city status without leaving stale recovery entries", async () => {
+    const store = setupStore();
+
+    mockLegacyGetStackerAtCycle.mockRejectedValue(new Error("read failed"));
+
+    await store.set(checkStackingRecoveryAtom, "mia");
+
+    expect(store.get(miaStackingRecoveryEntriesAtom)).toEqual([]);
+    expect(store.get(miaStackingRecoveryStatusAtom)).toMatchObject({
+      isChecking: false,
+      error: "read failed",
+    });
+  });
+
+  it("keys recovery entries by address so wallet changes hide stale results", async () => {
+    const store = setupStore(TEST_ADDRESS);
+
+    mockDaoGetStacker.mockImplementation(async (_city, _userId, cycle) => {
+      return {
+        ok: true,
+        data: { stacked: 1, claimable: cycle === 85 ? 123_000_000 : 0 },
+      };
+    });
+
+    await store.set(checkStackingRecoveryAtom, "mia");
+    expect(store.get(miaStackingRecoveryEntriesAtom)).toHaveLength(1);
+
+    store.set(stxAddressAtom, "SP2OTHERWALLET000000000000000000000000000");
+
+    expect(store.get(miaStackingRecoveryEntriesAtom)).toEqual([]);
+    expect(store.get(nycStackingRecoveryEntriesAtom)).toEqual([]);
+    expect(store.get(miaStackingRecoveryStatusAtom)).toMatchObject({
+      isChecking: false,
+      error: null,
+      checkedAt: null,
+    });
+  });
+});

--- a/src/store/stacking-recovery.ts
+++ b/src/store/stacking-recovery.ts
@@ -1,0 +1,227 @@
+import { atom } from "jotai";
+import {
+  CityName,
+  Version,
+  VERSIONS,
+  CITY_CONFIG,
+} from "../config/city-config";
+import { stxAddressAtom, userIdsAtom } from "./stacks";
+import { StackingEntry } from "./claims";
+import { getUserIdForVersion } from "../utilities/claim-verification";
+import {
+  daoGetStacker,
+  legacyGetStackerAtCycle,
+} from "../utilities/contract-reads";
+
+export interface StackingRecoveryEntry extends StackingEntry {
+  isRecovery: true;
+}
+
+export interface StackingRecoveryStatus {
+  isChecking: boolean;
+  error: string | null;
+  checkedAt: number | null;
+}
+
+type RecoveryEntriesByCity = Record<CityName, StackingRecoveryEntry[]>;
+type RecoveryStatusByCity = Record<CityName, StackingRecoveryStatus>;
+
+interface RecoveryEntriesState {
+  address: string | null;
+  entries: RecoveryEntriesByCity;
+}
+
+interface RecoveryStatusState {
+  address: string | null;
+  statuses: RecoveryStatusByCity;
+}
+
+const emptyEntries: RecoveryEntriesByCity = {
+  mia: [],
+  nyc: [],
+};
+
+const emptyStatus = (): StackingRecoveryStatus => ({
+  isChecking: false,
+  error: null,
+  checkedAt: null,
+});
+
+const emptyStatuses: RecoveryStatusByCity = {
+  mia: emptyStatus(),
+  nyc: emptyStatus(),
+};
+
+const stackingRecoveryEntriesAtom = atom<RecoveryEntriesState>({
+  address: null,
+  entries: emptyEntries,
+});
+const stackingRecoveryStatusAtom = atom<RecoveryStatusState>({
+  address: null,
+  statuses: emptyStatuses,
+});
+
+function isLegacyVersion(version: Version): version is "legacyV1" | "legacyV2" {
+  return version === "legacyV1" || version === "legacyV2";
+}
+
+function isDaoVersion(version: Version): version is "daoV1" | "daoV2" {
+  return version === "daoV1" || version === "daoV2";
+}
+
+function createRecoveryEntry(
+  city: CityName,
+  version: Version,
+  cycle: number,
+  amountTokens: number
+): StackingRecoveryEntry {
+  const contractId = CITY_CONFIG[city][version].stacking.contractId;
+
+  return {
+    txId: `recovery-${city}-${version}-${cycle}`,
+    cycle,
+    city,
+    version,
+    contractId,
+    functionName: "claim-stacking-reward",
+    amountTokens: BigInt(amountTokens),
+    status: "claimable",
+    isRecovery: true,
+  };
+}
+
+function getRecoveryCandidateCycles(endCycle: number): number[] {
+  const cycles = endCycle > 1 ? [endCycle - 1, endCycle] : [endCycle];
+  return Array.from(new Set(cycles));
+}
+
+async function getRecoverableAmount(
+  city: CityName,
+  version: Version,
+  userId: number,
+  cycle: number
+): Promise<number> {
+  if (isLegacyVersion(version)) {
+    const result = await legacyGetStackerAtCycle(city, version, userId, cycle);
+    if (!result.ok) {
+      throw new Error(result.error || "Failed to check legacy stacking recovery");
+    }
+    return result.data?.toReturn ?? 0;
+  }
+
+  if (isDaoVersion(version)) {
+    const result = await daoGetStacker(city, userId, cycle);
+    if (!result.ok) {
+      throw new Error(result.error || "Failed to check DAO stacking recovery");
+    }
+    return result.data?.claimable ?? 0;
+  }
+
+  return 0;
+}
+
+export const miaStackingRecoveryEntriesAtom = atom((get) => {
+  const address = get(stxAddressAtom);
+  const state = get(stackingRecoveryEntriesAtom);
+  return state.address === address ? state.entries.mia : [];
+});
+
+export const nycStackingRecoveryEntriesAtom = atom((get) => {
+  const address = get(stxAddressAtom);
+  const state = get(stackingRecoveryEntriesAtom);
+  return state.address === address ? state.entries.nyc : [];
+});
+
+export const miaStackingRecoveryStatusAtom = atom((get) => {
+  const address = get(stxAddressAtom);
+  const state = get(stackingRecoveryStatusAtom);
+  return state.address === address ? state.statuses.mia : emptyStatus();
+});
+
+export const nycStackingRecoveryStatusAtom = atom((get) => {
+  const address = get(stxAddressAtom);
+  const state = get(stackingRecoveryStatusAtom);
+  return state.address === address ? state.statuses.nyc : emptyStatus();
+});
+
+export const checkStackingRecoveryAtom = atom(
+  null,
+  async (get, set, city: CityName) => {
+    const address = get(stxAddressAtom);
+    const userIds = get(userIdsAtom);
+    if (!address || !userIds) return;
+
+    const currentStatusState = get(stackingRecoveryStatusAtom);
+    const currentStatuses =
+      currentStatusState.address === address ? currentStatusState.statuses : emptyStatuses;
+    set(stackingRecoveryStatusAtom, {
+      address,
+      statuses: {
+        ...currentStatuses,
+        [city]: { isChecking: true, error: null, checkedAt: null },
+      },
+    });
+
+    try {
+      const entries: StackingRecoveryEntry[] = [];
+
+      for (const version of VERSIONS) {
+        const endCycle = CITY_CONFIG[city][version].stacking.endCycle;
+        if (endCycle === undefined) continue;
+
+        const userId = getUserIdForVersion(userIds, city, version);
+        if (userId === null) continue;
+
+        for (const cycle of getRecoveryCandidateCycles(endCycle)) {
+          const recoverableAmount = await getRecoverableAmount(
+            city,
+            version,
+            userId,
+            cycle
+          );
+
+          if (recoverableAmount > 0) {
+            entries.push(createRecoveryEntry(city, version, cycle, recoverableAmount));
+          }
+        }
+      }
+
+      const currentEntryState = get(stackingRecoveryEntriesAtom);
+      const currentEntries =
+        currentEntryState.address === address ? currentEntryState.entries : emptyEntries;
+      set(stackingRecoveryEntriesAtom, {
+        address,
+        entries: {
+          ...currentEntries,
+          [city]: entries,
+        },
+      });
+
+      const latestStatusState = get(stackingRecoveryStatusAtom);
+      const latestStatuses =
+        latestStatusState.address === address ? latestStatusState.statuses : emptyStatuses;
+      set(stackingRecoveryStatusAtom, {
+        address,
+        statuses: {
+          ...latestStatuses,
+          [city]: { isChecking: false, error: null, checkedAt: Date.now() },
+        },
+      });
+    } catch (error) {
+      const latestStatusState = get(stackingRecoveryStatusAtom);
+      const latestStatuses =
+        latestStatusState.address === address ? latestStatusState.statuses : emptyStatuses;
+      set(stackingRecoveryStatusAtom, {
+        address,
+        statuses: {
+          ...latestStatuses,
+          [city]: {
+            isChecking: false,
+            error: error instanceof Error ? error.message : String(error),
+            checkedAt: Date.now(),
+          },
+        },
+      });
+    }
+  }
+);

--- a/src/utilities/contract-reads/index.ts
+++ b/src/utilities/contract-reads/index.ts
@@ -11,7 +11,11 @@ export {
   isBlockWinner as legacyIsBlockWinner,
 } from "./legacy-mining";
 
-export { getStackingReward as legacyGetStackingReward } from "./legacy-stacking";
+export {
+  getStackingReward as legacyGetStackingReward,
+  getStackerAtCycle as legacyGetStackerAtCycle,
+  type LegacyStackerInfo,
+} from "./legacy-stacking";
 
 export { getUserId as legacyGetUserId } from "./legacy-user-registry";
 

--- a/src/utilities/contract-reads/legacy-stacking.ts
+++ b/src/utilities/contract-reads/legacy-stacking.ts
@@ -5,7 +5,7 @@
  * Replaces calls to api.citycoins.co
  */
 
-import { ClarityType, uintCV, hexToCV, UIntCV } from "@stacks/transactions";
+import { ClarityType, uintCV, hexToCV, TupleCV, UIntCV } from "@stacks/transactions";
 import { CityName, CITY_CONFIG } from "../../config/city-config";
 import { callReadOnlyFunction, ContractCallResult } from "../hiro-client";
 
@@ -28,6 +28,11 @@ function safeNumberFromBigInt(
 }
 
 type LegacyVersion = "legacyV1" | "legacyV2";
+
+export interface LegacyStackerInfo {
+  amountStacked: number;
+  toReturn: number;
+}
 
 /**
  * Get contract address and name for legacy stacking
@@ -110,6 +115,76 @@ export async function getStackingReward(
     }
 
     return { ok: false, error: `Unexpected response type: ${cv.type}` };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+/**
+ * Get stacker info for a user in a specific legacy cycle.
+ *
+ * Contract function: (get-stacker-at-cycle-or-default (rewardCycle uint) (userId uint))
+ * Returns: { amountStacked: uint, toReturn: uint }
+ *
+ * `toReturn` is the stacked CityCoins principal returned when claiming the final
+ * cycle of a lock period.
+ */
+export async function getStackerAtCycle(
+  city: CityName,
+  version: LegacyVersion,
+  userId: number,
+  cycle: number
+): Promise<ContractCallResult<LegacyStackerInfo>> {
+  const { address: contractAddress, name: contractName } = getStackingContract(
+    city,
+    version
+  );
+
+  const result = await callReadOnlyFunction(
+    contractAddress,
+    contractName,
+    "get-stacker-at-cycle-or-default",
+    [uintCV(cycle), uintCV(userId)],
+    contractAddress
+  );
+
+  if (!result.ok || !result.data) {
+    return { ok: false, error: result.error || "No result" };
+  }
+
+  try {
+    const cv = hexToCV(result.data);
+
+    if (cv.type !== ClarityType.Tuple) {
+      return { ok: false, error: `Unexpected response type: ${cv.type}` };
+    }
+
+    const tuple = cv as TupleCV;
+    const amountStacked = tuple.value.amountStacked as UIntCV | undefined;
+    const toReturn = tuple.value.toReturn as UIntCV | undefined;
+
+    const amountStackedConversion = safeNumberFromBigInt(
+      amountStacked?.value ?? 0n,
+      "Amount stacked"
+    );
+    if (!amountStackedConversion.ok) return amountStackedConversion;
+
+    const toReturnConversion = safeNumberFromBigInt(
+      toReturn?.value ?? 0n,
+      "Amount to return"
+    );
+    if (!toReturnConversion.ok) return toReturnConversion;
+
+    return {
+      ok: true,
+      data: {
+        amountStacked: amountStackedConversion.data,
+        toReturn: toReturnConversion.data,
+      },
+    };
   } catch (error) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- add read-only final-cycle recovery checks for each configured stacking contract
- support legacy principal recovery via get-stacker-at-cycle-or-default and DAO recovery via get-stacker claimable
- show a separate stacked token recovery table in MIA/NYC tabs and reuse the existing stacking claim transaction path
- suppress duplicate stacking reward rows for the same city/version/cycle when a recovery row is present

## Testing
- npx vitest run src/store/__tests__/claims.test.ts src/utilities/__tests__/claim-transactions.test.ts
- npm run build