### PR TITLE
Isolate account state on logout; skip known empty stacking cycles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,12 @@ import { Provider } from "./components/ui/provider";
 import { Toaster } from "./components/ui/toaster";
 import { useStorageMonitor } from "./hooks/use-storage-monitor";
 import { useBroadcastSync } from "./hooks/use-broadcast-sync";
-import { migrateStoredTxsAtom } from "./store/stacks";
+import {
+  migrateAccountAtomsByAddressAtom,
+  migrateStoredTxsAtom,
+} from "./store/stacks";
 import { migrateVerificationCacheAtom } from "./store/verification";
+import { migratePendingClaimsByAddressAtom } from "./store/claims";
 
 /**
  * Inner app content with storage monitoring and cross-tab sync
@@ -21,15 +25,32 @@ const AppContent = () => {
   // Enable cross-tab synchronization for verification cache
   useBroadcastSync();
 
-  // One-shot migrations: slim legacy transaction cache and rewrite any
-  // legacy "unpaid" verification entries to "no-payout". Both are no-ops
-  // when nothing needs migrating.
+  // One-shot migrations. Each is a no-op when nothing needs migrating:
+  //   - migrateAccountAtomsByAddress: move legacy single-key per-account
+  //     caches (acctTxs, userIds, bnsName, mempool, balances) into the new
+  //     address-keyed records under the connected wallet.
+  //   - migrateStoredTxs: slim legacy fat transactions in the cached blob.
+  //   - migrateVerificationCache: rewrite legacy "unpaid" entries to
+  //     "no-payout".
+  //   - migratePendingClaimsByAddress: reshape the flat pending-claims array
+  //     into a per-address record.
+  // Order matters: per-address migration must run before migrateStoredTxs,
+  // since the latter reads via the new address-scoped acctTxs atom.
+  const migrateAccountAtomsByAddress = useSetAtom(migrateAccountAtomsByAddressAtom);
   const migrateStoredTxs = useSetAtom(migrateStoredTxsAtom);
   const migrateVerificationCache = useSetAtom(migrateVerificationCacheAtom);
+  const migratePendingClaimsByAddress = useSetAtom(migratePendingClaimsByAddressAtom);
   useEffect(() => {
+    migrateAccountAtomsByAddress();
     migrateStoredTxs();
     migrateVerificationCache();
-  }, [migrateStoredTxs, migrateVerificationCache]);
+    migratePendingClaimsByAddress();
+  }, [
+    migrateAccountAtomsByAddress,
+    migrateStoredTxs,
+    migrateVerificationCache,
+    migratePendingClaimsByAddress,
+  ]);
 
   return (
     <Flex direction="column" minH="100vh">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Flex, Separator } from "@chakra-ui/react";
-import { useSetAtom } from "jotai";
+import { useAtomValue, useSetAtom } from "jotai";
 import { useEffect } from "react";
+import { stxAddressAtom } from "./store/stacks";
 import Content from "./components/layout/page-content";
 import Footer from "./components/layout/page-footer";
 import Header from "./components/layout/page-header";
@@ -28,7 +29,10 @@ const AppContent = () => {
   // One-shot migrations. Each is a no-op when nothing needs migrating:
   //   - migrateAccountAtomsByAddress: move legacy single-key per-account
   //     caches (acctTxs, userIds, bnsName, mempool, balances) into the new
-  //     address-keyed records under the connected wallet.
+  //     address-keyed records under the connected wallet. Requires a
+  //     connected wallet to know which slice to assign the legacy data to,
+  //     so it also re-runs when stxAddress later becomes available (e.g.
+  //     user lands on the app signed out, then connects).
   //   - migrateStoredTxs: slim legacy fat transactions in the cached blob.
   //   - migrateVerificationCache: rewrite legacy "unpaid" entries to
   //     "no-payout".
@@ -36,6 +40,7 @@ const AppContent = () => {
   //     into a per-address record.
   // Order matters: per-address migration must run before migrateStoredTxs,
   // since the latter reads via the new address-scoped acctTxs atom.
+  const stxAddress = useAtomValue(stxAddressAtom);
   const migrateAccountAtomsByAddress = useSetAtom(migrateAccountAtomsByAddressAtom);
   const migrateStoredTxs = useSetAtom(migrateStoredTxsAtom);
   const migrateVerificationCache = useSetAtom(migrateVerificationCacheAtom);
@@ -46,6 +51,7 @@ const AppContent = () => {
     migrateVerificationCache();
     migratePendingClaimsByAddress();
   }, [
+    stxAddress,
     migrateAccountAtomsByAddress,
     migrateStoredTxs,
     migrateVerificationCache,

--- a/src/components/auth/sign-out.tsx
+++ b/src/components/auth/sign-out.tsx
@@ -1,21 +1,32 @@
 import { Button } from "@chakra-ui/react";
 import { disconnect } from "@stacks/connect";
 import { useSetAtom } from "jotai";
-import { stxAddressAtom } from "../../store/stacks";
 import { useClearUserData } from "../../hooks/use-clear-user-data";
+import { verificationProgressAtom } from "../../store/verification";
 
 function SignOut(props: { variant?: string }) {
-  const setStxAddress = useSetAtom(stxAddressAtom);
   const clearUserData = useClearUserData();
+  const setVerificationProgress = useSetAtom(verificationProgressAtom);
   return (
     <Button
       variant={props.variant || "solid"}
       title="Sign Out"
       onClick={() => {
-        // sign out of the wallet
         try {
           disconnect();
-          setStxAddress(null); // Clear the STX address in the store
+          // Reset any in-flight verification UI immediately so the prior
+          // account's progress banner doesn't linger while the running loop
+          // notices the address change and breaks.
+          setVerificationProgress({
+            isRunning: false,
+            type: null,
+            city: null,
+            current: 0,
+            total: 0,
+            currentItem: "",
+          });
+          // clearUserData wipes the connected wallet's per-address slices and
+          // then clears stxAddress, so it must run with the address still set.
           clearUserData();
         } catch (error) {
           console.error("Error while signing out: ", error);

--- a/src/components/auth/sign-out.tsx
+++ b/src/components/auth/sign-out.tsx
@@ -1,11 +1,18 @@
 import { Button } from "@chakra-ui/react";
 import { disconnect } from "@stacks/connect";
 import { useSetAtom } from "jotai";
-import { useClearUserData } from "../../hooks/use-clear-user-data";
+import { stxAddressAtom } from "../../store/stacks";
 import { verificationProgressAtom } from "../../store/verification";
 
+/**
+ * Disconnects the wallet without touching cached per-address data. The
+ * dedicated "Clear Data" button is the explicit path for wiping the
+ * connected wallet's slice; signing out alone preserves it so the user
+ * can reconnect with the same wallet later and pick up their cached
+ * transactions / user IDs / pending claims without a fresh re-fetch.
+ */
 function SignOut(props: { variant?: string }) {
-  const clearUserData = useClearUserData();
+  const setStxAddress = useSetAtom(stxAddressAtom);
   const setVerificationProgress = useSetAtom(verificationProgressAtom);
   return (
     <Button
@@ -14,9 +21,9 @@ function SignOut(props: { variant?: string }) {
       onClick={() => {
         try {
           disconnect();
-          // Reset any in-flight verification UI immediately so the prior
-          // account's progress banner doesn't linger while the running loop
-          // notices the address change and breaks.
+          // Reset any in-flight verification UI so the prior account's
+          // progress banner doesn't linger while the running loop notices
+          // the address change and breaks.
           setVerificationProgress({
             isRunning: false,
             type: null,
@@ -25,9 +32,7 @@ function SignOut(props: { variant?: string }) {
             total: 0,
             currentItem: "",
           });
-          // clearUserData wipes the connected wallet's per-address slices and
-          // then clears stxAddress, so it must run with the address still set.
-          clearUserData();
+          setStxAddress(null);
         } catch (error) {
           console.error("Error while signing out: ", error);
         }

--- a/src/hooks/use-clear-user-data.tsx
+++ b/src/hooks/use-clear-user-data.tsx
@@ -1,28 +1,82 @@
 import { useCallback } from "react";
-import { WritableAtom } from "jotai";
+import { PrimitiveAtom, WritableAtom } from "jotai";
 import { RESET, useAtomCallback } from "jotai/utils";
-import { commonLocalStorageAtoms } from "../store/common";
-import { stacksLocalStorageAtoms } from "../store/stacks";
+import { activeTabAtom } from "../store/common";
 import { ccip016LocalStorageAtoms } from "../store/ccip-016";
+import {
+  blockHeightsAtom,
+  perAddressStorageAtoms,
+  stxAddressAtom,
+} from "../store/stacks";
+import {
+  pendingClaimTransactionsByAddressAtom,
+  PendingClaimTransaction,
+} from "../store/claims";
+import {
+  verificationCacheByAddressAtom,
+  VerificationResult,
+} from "../store/verification";
 
 type AnyWritableAtom = WritableAtom<any, any, any>;
 
+/**
+ * Clears the connected wallet's data:
+ *   - per-address atoms (txs, mempool, balances, user IDs, BNS name,
+ *     pending claims, verification cache) have just the current address's
+ *     slice removed, leaving other accounts' caches intact.
+ *   - global non-account atoms (active tab, block heights, CCIP-016 state)
+ *     are reset to defaults — these don't belong to any one wallet.
+ *   - stxAddress is cleared last so writes above route to the right slice.
+ */
 export const useClearUserData = () => {
   const clearData = useAtomCallback(
     useCallback((get, set) => {
-      const resetAtom = (atom: AnyWritableAtom) => {
-        set(atom, RESET);
-      };
+      const address = get(stxAddressAtom);
 
-      // combine all localstorage atoms
-      const allLocalStorageAtoms = [
+      if (address) {
+        // Remove only this wallet's slice from each per-address record so
+        // re-connecting another wallet keeps its own cache.
+        for (const byAddressAtom of perAddressStorageAtoms) {
+          const typed = byAddressAtom as PrimitiveAtom<Record<string, unknown>>;
+          const current = get(typed);
+          if (current && address in current) {
+            const next = { ...current };
+            delete next[address];
+            set(typed, next);
+          }
+        }
+
+        const pendingClaims = get(pendingClaimTransactionsByAddressAtom);
+        if (address in pendingClaims) {
+          const next: Record<string, PendingClaimTransaction[]> = {
+            ...pendingClaims,
+          };
+          delete next[address];
+          set(pendingClaimTransactionsByAddressAtom, next);
+        }
+
+        const verificationCache = get(verificationCacheByAddressAtom);
+        if (address in verificationCache) {
+          const next: Record<string, Record<string, VerificationResult>> = {
+            ...verificationCache,
+          };
+          delete next[address];
+          set(verificationCacheByAddressAtom, next);
+        }
+      }
+
+      // Global, non-account atoms — reset to defaults.
+      const globalAtoms: AnyWritableAtom[] = [
+        activeTabAtom,
+        blockHeightsAtom,
         ...ccip016LocalStorageAtoms,
-        ...commonLocalStorageAtoms,
-        ...stacksLocalStorageAtoms,
       ];
+      for (const atom of globalAtoms) {
+        set(atom, RESET);
+      }
 
-      // reset all localstorage atoms
-      allLocalStorageAtoms.forEach(resetAtom);
+      // Clear identity last; any address-scoped writes above need it.
+      set(stxAddressAtom, RESET);
     }, [])
   );
 

--- a/src/store/__tests__/claims.test.ts
+++ b/src/store/__tests__/claims.test.ts
@@ -15,6 +15,7 @@
 
 import { describe, it, expect } from "vitest";
 import type { MiningEntry, StackingEntry, MiningStatus, StackingStatus } from "../claims";
+import { KNOWN_NO_PAYOUT_CYCLES } from "../claims";
 import type { VerificationStatus, VerificationResult } from "../verification";
 
 // =============================================================================
@@ -448,7 +449,10 @@ function resolveMiningEntryStatus(
 }
 
 /**
- * Simulate the priority resolution logic from verifiedStackingEntriesAtom
+ * Simulate the priority resolution logic from verifiedStackingEntriesAtom.
+ * Mirrors the real atom: tx history wins, then locked, then the
+ * pre-marked no-payout override (which intentionally beats a stale cache),
+ * then the verification cache, then the base unverified status.
  */
 function resolveStackingEntryStatus(
   entry: StackingEntry,
@@ -464,15 +468,35 @@ function resolveStackingEntryStatus(
     return "locked";
   }
 
-  // Priority 3: Verification cache
+  // Priority 3: pre-marked no-payout from stackingEntriesAtom takes
+  // precedence over any cached verification result so the known empty
+  // cycles can't be flipped back to claimable by stale cache data.
+  if (entry.status === "no-payout") {
+    return "no-payout";
+  }
+
+  // Priority 4: Verification cache
   const key = createCacheKey(entry.city, entry.version, "stacking", entry.cycle);
   const cached = verificationCache[key];
   if (cached) {
     return mapVerificationToStackingStatus(cached.status);
   }
 
-  // Priority 4: Base status (unverified)
+  // Priority 5: Base status (unverified)
   return entry.status;
+}
+
+/**
+ * Simulate the no-payout pre-mark applied in stackingEntriesAtom: an
+ * entry that would otherwise be "unverified" but whose cycle is in the
+ * known empty set is pre-marked "no-payout" before reaching the
+ * verification layer.
+ */
+function preMarkStackingEntry(entry: StackingEntry): StackingEntry {
+  if (entry.status === "unverified" && KNOWN_NO_PAYOUT_CYCLES.has(entry.cycle)) {
+    return { ...entry, status: "no-payout" };
+  }
+  return entry;
 }
 
 describe("Mining Status Priority Resolution", () => {
@@ -592,6 +616,56 @@ describe("Stacking Status Priority Resolution", () => {
     const entry = createStackingEntry(20, "unverified");
     const cache = {};
     expect(resolveStackingEntryStatus(entry, cache)).toBe("unverified");
+  });
+});
+
+// =============================================================================
+// KNOWN-NO-PAYOUT CYCLE PRE-MARK TESTS
+// =============================================================================
+
+describe("KNOWN_NO_PAYOUT_CYCLES pre-mark", () => {
+  it.each([56, 57, 58, 59, 84])(
+    "pre-marks cycle %i as no-payout instead of unverified",
+    (cycle) => {
+      const entry = preMarkStackingEntry(
+        createStackingEntry(cycle, "unverified")
+      );
+      expect(entry.status).toBe("no-payout");
+    }
+  );
+
+  it("leaves cycle 85 as unverified so the verify/claim path stays in play", () => {
+    const entry = preMarkStackingEntry(createStackingEntry(85, "unverified"));
+    expect(entry.status).toBe("unverified");
+  });
+
+  it("does not downgrade a claimed entry on a known empty cycle", () => {
+    const entry = preMarkStackingEntry(
+      createStackingEntry(56, "claimed", { claimTxId: "0xclaim" })
+    );
+    expect(entry.status).toBe("claimed");
+  });
+
+  it("does not downgrade a locked entry on a known empty cycle", () => {
+    const entry = preMarkStackingEntry(createStackingEntry(56, "locked"));
+    expect(entry.status).toBe("locked");
+  });
+
+  it("keeps no-payout sticky even with a cached claimable verification", () => {
+    const entry = preMarkStackingEntry(createStackingEntry(56, "unverified"));
+    const staleCache = {
+      [createCacheKey("mia", "daoV2", "stacking", 56)]: createVerificationResult(
+        "claimable"
+      ),
+    };
+    expect(resolveStackingEntryStatus(entry, staleCache)).toBe("no-payout");
+  });
+
+  it("applies the override to NYC cycles the same way as MIA", () => {
+    const entry = preMarkStackingEntry(
+      createStackingEntry(57, "unverified", { city: "nyc" })
+    );
+    expect(entry.status).toBe("no-payout");
   });
 });
 

--- a/src/store/__tests__/stacks.test.ts
+++ b/src/store/__tests__/stacks.test.ts
@@ -9,7 +9,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createStore } from "jotai";
 import LZString from "lz-string";
 import type { Transaction } from "@stacks/stacks-blockchain-api-types";
-import { acctTxsAtom, decompressedAcctTxsAtom } from "../stacks";
+import { acctTxsAtom, decompressedAcctTxsAtom, stxAddressAtom } from "../stacks";
+
+const TEST_ADDRESS = "SP1TEST123";
 
 // =============================================================================
 // TEST FIXTURES
@@ -78,6 +80,9 @@ describe("decompressedAcctTxsAtom memoization", () => {
 
   beforeEach(() => {
     store = createStore();
+    // acctTxsAtom routes reads/writes through the connected wallet's slice,
+    // so the test store needs an address before it can store anything.
+    store.set(stxAddressAtom, TEST_ADDRESS);
     // Spy on LZString.decompress to count calls
     decompressSpy = vi.spyOn(LZString, "decompress");
   });
@@ -228,6 +233,7 @@ describe("decompressedAcctTxsAtom memoization", () => {
 describe("decompressedAcctTxsAtom performance", () => {
   it("should handle large transaction sets efficiently", () => {
     const store = createStore();
+    store.set(stxAddressAtom, TEST_ADDRESS);
     const compressed = createCompressedTransactions(1000);
 
     // Set compressed data

--- a/src/store/claims.ts
+++ b/src/store/claims.ts
@@ -281,10 +281,15 @@ export const addPendingClaimTransactionAtom = atom(
  * in this set — it's the last claim cycle after the shutdown and many
  * stackers legitimately land there, so the verify path stays in play.
  *
- * Cycle numbers do not overlap across city/version, so a single set
- * suffices (no city/version filter needed).
+ * The override is intentionally applied globally with no city/version
+ * filter: CITY_CONFIG defines overlapping cycle ranges across MIA/NYC and
+ * across DAO versions, but the empty-payout situation for these specific
+ * cycle numbers is chain-wide, so the same cycle number means the same
+ * outcome regardless of city or version.
  */
-const KNOWN_NO_PAYOUT_CYCLES = new Set([56, 57, 58, 59, 84]);
+export const KNOWN_NO_PAYOUT_CYCLES: ReadonlySet<number> = new Set([
+  56, 57, 58, 59, 84,
+]);
 
 /**
  * Pre-compute function sets once (not on every iteration)

--- a/src/store/claims.ts
+++ b/src/store/claims.ts
@@ -196,10 +196,58 @@ export interface PendingClaimTransaction {
   submittedAt: number;
 }
 
-export const pendingClaimTransactionsAtom = atomWithStorage<PendingClaimTransaction[]>(
-  "citycoins-pending-claim-transactions",
-  []
+export const pendingClaimTransactionsByAddressAtom = atomWithStorage<
+  Record<string, PendingClaimTransaction[]>
+>("citycoins-pending-claim-transactions-by-address", {});
+
+/**
+ * Pending claim transactions scoped to the connected wallet. The rows still
+ * carry `address` for back-compat with consumers that match against it, but
+ * the storage layer is keyed by address so switching accounts shows the
+ * right pending state instead of a mixed feed.
+ */
+export const pendingClaimTransactionsAtom = atom(
+  (get) => {
+    const address = get(stxAddressAtom);
+    if (!address) return [];
+    return get(pendingClaimTransactionsByAddressAtom)[address] ?? [];
+  },
+  (get, set, value: PendingClaimTransaction[]) => {
+    const address = get(stxAddressAtom);
+    if (!address) return;
+    const current = get(pendingClaimTransactionsByAddressAtom);
+    set(pendingClaimTransactionsByAddressAtom, { ...current, [address]: value });
+  }
 );
+
+/**
+ * One-shot migration: re-shape the legacy flat pending-claims array (keyed by
+ * a single localStorage key, with `address` on each row) into the new
+ * per-address record. No-op once the legacy key is gone.
+ */
+export const migratePendingClaimsByAddressAtom = atom(null, (get, set) => {
+  const legacyRaw = localStorage.getItem("citycoins-pending-claim-transactions");
+  if (legacyRaw === null) return;
+  try {
+    const legacy = JSON.parse(legacyRaw) as PendingClaimTransaction[];
+    if (Array.isArray(legacy) && legacy.length > 0) {
+      const grouped: Record<string, PendingClaimTransaction[]> = {};
+      for (const row of legacy) {
+        if (!row?.address) continue;
+        (grouped[row.address] ||= []).push(row);
+      }
+      const current = get(pendingClaimTransactionsByAddressAtom);
+      const merged: Record<string, PendingClaimTransaction[]> = { ...current };
+      for (const [addr, rows] of Object.entries(grouped)) {
+        if (merged[addr] === undefined) merged[addr] = rows;
+      }
+      set(pendingClaimTransactionsByAddressAtom, merged);
+    }
+  } catch {
+    // Ignore — broken legacy cache is dropped.
+  }
+  localStorage.removeItem("citycoins-pending-claim-transactions");
+});
 
 export const addPendingClaimTransactionAtom = atom(
   null,
@@ -219,13 +267,24 @@ export const addPendingClaimTransactionAtom = atom(
       nextClaim,
       ...pendingClaims.filter((pending) => {
         return (
-          pending.address !== address ||
           createClaimKey(pending.city, pending.version, pending.type, pending.id) !== key
         );
       }),
     ]);
   }
 );
+
+/**
+ * Cycles that are known to have no stacking payout. Pre-marked as
+ * "no-payout" so users don't waste a verify call (and a button click) on a
+ * round-trip we already know the answer to. Cycle 85 is intentionally not
+ * in this set — it's the last claim cycle after the shutdown and many
+ * stackers legitimately land there, so the verify path stays in play.
+ *
+ * Cycle numbers do not overlap across city/version, so a single set
+ * suffices (no city/version filter needed).
+ */
+const KNOWN_NO_PAYOUT_CYCLES = new Set([56, 57, 58, 59, 84]);
 
 /**
  * Pre-compute function sets once (not on every iteration)
@@ -656,6 +715,10 @@ export const stackingEntriesAtom = atom((get) => {
     } else if (failedTxId) {
       return { ...entry, status: "unavailable" as StackingStatus, claimTxId: failedTxId };
     }
+    // Skip the verify round-trip for cycles we already know have no payout.
+    if (KNOWN_NO_PAYOUT_CYCLES.has(entry.cycle) && entry.status === "unverified") {
+      return { ...entry, status: "no-payout" as StackingStatus };
+    }
     return entry;
   });
 });
@@ -687,6 +750,13 @@ export const verifiedStackingEntriesAtom = atom((get) => {
 
     // If still locked (cycle not complete), keep as locked
     if (entry.status === "locked") {
+      return entry;
+    }
+
+    // Honor the pre-marked no-payout status from `stackingEntriesAtom` and
+    // ignore any cached verification result — these cycles are known to have
+    // no payout and the cache could otherwise hold a stale claimable verdict.
+    if (entry.status === "no-payout") {
       return entry;
     }
 

--- a/src/store/stacks.ts
+++ b/src/store/stacks.ts
@@ -6,7 +6,7 @@ import {
 } from "@stacks/stacks-blockchain-api-types";
 import { HIRO_API } from "./common";
 import { hiroFetch } from "../utilities/hiro-client";
-import { Setter, atom } from "jotai";
+import { Getter, Setter, atom } from "jotai";
 import LZString from "lz-string";
 import { decodeTxArgs, isValidMiningTxArgs, isValidMiningClaimTxArgs, isValidStackingTxArgs, isValidStackingClaimTxArgs } from "../utilities/transactions";
 import { fetchAllUserIds, UserIds } from "../utilities/claim-verification";
@@ -41,24 +41,90 @@ export const stxAddressAtom = atomWithStorage<string | null>(
   null
 );
 
-export const bnsNameAtom = atomWithStorage<string | null>(
-  "citycoins-stacks-bnsName",
-  null
+// =============================================================================
+// PER-ACCOUNT STORAGE
+//
+// Each per-account atom is backed by a `Record<address, value>` in
+// localStorage. The legacy single-key atoms are derived: they read/write the
+// slice for the currently-connected wallet. This keeps state isolated when the
+// user switches accounts and prevents leftover work (verification, refetches)
+// from polluting the new account's cache.
+// =============================================================================
+
+export const bnsNameByAddressAtom = atomWithStorage<Record<string, string | null>>(
+  "citycoins-stacks-bnsName-by-address",
+  {}
 );
 
-export const acctTxsAtom = atomWithStorage<string>(
-  "citycoins-stacks-acctTxs",
-  ""
+export const bnsNameAtom = atom(
+  (get) => {
+    const address = get(stxAddressAtom);
+    if (!address) return null;
+    return get(bnsNameByAddressAtom)[address] ?? null;
+  },
+  (get, set, value: string | null) => {
+    const address = get(stxAddressAtom);
+    if (!address) return;
+    const current = get(bnsNameByAddressAtom);
+    set(bnsNameByAddressAtom, { ...current, [address]: value });
+  }
 );
 
-export const acctMempoolTxsAtom = atomWithStorage<Transaction[]>(
-  "citycoins-stacks-acctMempoolTxs",
-  []
+export const acctTxsByAddressAtom = atomWithStorage<Record<string, string>>(
+  "citycoins-stacks-acctTxs-by-address",
+  {}
 );
 
-export const acctBalancesAtom = atomWithStorage(
-  "citycoins-stacks-acctBalances",
-  null
+export const acctTxsAtom = atom(
+  (get) => {
+    const address = get(stxAddressAtom);
+    if (!address) return "";
+    return get(acctTxsByAddressAtom)[address] ?? "";
+  },
+  (get, set, value: string) => {
+    const address = get(stxAddressAtom);
+    if (!address) return;
+    const current = get(acctTxsByAddressAtom);
+    set(acctTxsByAddressAtom, { ...current, [address]: value });
+  }
+);
+
+export const acctMempoolTxsByAddressAtom = atomWithStorage<Record<string, Transaction[]>>(
+  "citycoins-stacks-acctMempoolTxs-by-address",
+  {}
+);
+
+export const acctMempoolTxsAtom = atom(
+  (get) => {
+    const address = get(stxAddressAtom);
+    if (!address) return [];
+    return get(acctMempoolTxsByAddressAtom)[address] ?? [];
+  },
+  (get, set, value: Transaction[]) => {
+    const address = get(stxAddressAtom);
+    if (!address) return;
+    const current = get(acctMempoolTxsByAddressAtom);
+    set(acctMempoolTxsByAddressAtom, { ...current, [address]: value });
+  }
+);
+
+export const acctBalancesByAddressAtom = atomWithStorage<Record<string, unknown>>(
+  "citycoins-stacks-acctBalances-by-address",
+  {}
+);
+
+export const acctBalancesAtom = atom(
+  (get) => {
+    const address = get(stxAddressAtom);
+    if (!address) return null;
+    return get(acctBalancesByAddressAtom)[address] ?? null;
+  },
+  (get, set, value: unknown) => {
+    const address = get(stxAddressAtom);
+    if (!address) return;
+    const current = get(acctBalancesByAddressAtom);
+    set(acctBalancesByAddressAtom, { ...current, [address]: value });
+  }
 );
 
 /**
@@ -67,21 +133,49 @@ export const acctBalancesAtom = atomWithStorage(
  * - Legacy: Per-city, per-version IDs from each core contract
  * - DAO: Shared ID from ccd003-user-registry
  *
- * Cached indefinitely (clear data button resets all atoms).
+ * Cached indefinitely (clear data button resets the current address's slice).
  */
-export const userIdsAtom = atomWithStorage<UserIds | null>(
-  "citycoins-user-ids",
-  null
+export const userIdsByAddressAtom = atomWithStorage<Record<string, UserIds | null>>(
+  "citycoins-user-ids-by-address",
+  {}
 );
+
+export const userIdsAtom = atom(
+  (get) => {
+    const address = get(stxAddressAtom);
+    if (!address) return null;
+    return get(userIdsByAddressAtom)[address] ?? null;
+  },
+  (get, set, value: UserIds | null) => {
+    const address = get(stxAddressAtom);
+    if (!address) return;
+    const current = get(userIdsByAddressAtom);
+    set(userIdsByAddressAtom, { ...current, [address]: value });
+  }
+);
+
+/**
+ * Per-account storage atoms. Used by `useClearUserData` to wipe the current
+ * wallet's slice without touching other accounts' caches. `stxAddressAtom` and
+ * `blockHeightsAtom` are intentionally absent — address is identity (cleared
+ * separately on logout) and block heights are chain state, not account state.
+ */
+export const perAddressStorageAtoms = [
+  bnsNameByAddressAtom,
+  acctTxsByAddressAtom,
+  acctMempoolTxsByAddressAtom,
+  acctBalancesByAddressAtom,
+  userIdsByAddressAtom,
+];
 
 export const stacksLocalStorageAtoms = [
   blockHeightsAtom,
   stxAddressAtom,
-  bnsNameAtom,
-  acctTxsAtom,
-  acctMempoolTxsAtom,
-  acctBalancesAtom,
-  userIdsAtom,
+  bnsNameByAddressAtom,
+  acctTxsByAddressAtom,
+  acctMempoolTxsByAddressAtom,
+  acctBalancesByAddressAtom,
+  userIdsByAddressAtom,
 ];
 
 /////////////////////////
@@ -262,7 +356,7 @@ export const transactionsAtom = atom(
       progress: 0,
     });
     try {
-      const newTxs = await getAllTxs(address, update, set);
+      const newTxs = await getAllTxs(address, update, get, set);
       set(transactionFetchStatusAtom, {
         isLoading: false,
         error: null,
@@ -299,6 +393,90 @@ export const migrateStoredTxsAtom = atom(null, (get, set) => {
     set(acctTxsAtom, LZString.compress(JSON.stringify(slim)));
   } catch {
     // Ignore — corrupt cache will be refetched.
+  }
+});
+
+/**
+ * One-shot migration: move legacy single-key per-account caches into the new
+ * by-address records, scoped to the currently connected wallet. Without this,
+ * existing users would lose their cached transactions / user IDs on upgrade
+ * and have to re-fetch from scratch. No-op when no legacy keys are present or
+ * when no wallet is connected (we don't know which address to assign the data
+ * to). Old keys are removed after a successful migration.
+ */
+const LEGACY_ACCOUNT_KEYS = [
+  "citycoins-stacks-acctTxs",
+  "citycoins-stacks-acctMempoolTxs",
+  "citycoins-stacks-acctBalances",
+  "citycoins-stacks-bnsName",
+  "citycoins-user-ids",
+] as const;
+
+function readLegacyJSON<T>(key: string): T | undefined {
+  const raw = localStorage.getItem(key);
+  if (raw === null) return undefined;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+export const migrateAccountAtomsByAddressAtom = atom(null, (get, set) => {
+  const address = get(stxAddressAtom);
+  if (!address) return;
+
+  // acctTxs (string)
+  const legacyTxs = readLegacyJSON<string>("citycoins-stacks-acctTxs");
+  if (typeof legacyTxs === "string" && legacyTxs.length > 0) {
+    const current = get(acctTxsByAddressAtom);
+    if (current[address] === undefined) {
+      set(acctTxsByAddressAtom, { ...current, [address]: legacyTxs });
+    }
+  }
+
+  // acctMempoolTxs (Transaction[])
+  const legacyMempool = readLegacyJSON<Transaction[]>(
+    "citycoins-stacks-acctMempoolTxs"
+  );
+  if (Array.isArray(legacyMempool)) {
+    const current = get(acctMempoolTxsByAddressAtom);
+    if (current[address] === undefined) {
+      set(acctMempoolTxsByAddressAtom, { ...current, [address]: legacyMempool });
+    }
+  }
+
+  // acctBalances (unknown)
+  const legacyBalances = readLegacyJSON<unknown>("citycoins-stacks-acctBalances");
+  if (legacyBalances !== undefined && legacyBalances !== null) {
+    const current = get(acctBalancesByAddressAtom);
+    if (current[address] === undefined) {
+      set(acctBalancesByAddressAtom, { ...current, [address]: legacyBalances });
+    }
+  }
+
+  // bnsName (string | null)
+  const legacyBns = readLegacyJSON<string | null>("citycoins-stacks-bnsName");
+  if (legacyBns !== undefined) {
+    const current = get(bnsNameByAddressAtom);
+    if (current[address] === undefined) {
+      set(bnsNameByAddressAtom, { ...current, [address]: legacyBns });
+    }
+  }
+
+  // userIds (UserIds | null)
+  const legacyUserIds = readLegacyJSON<UserIds | null>("citycoins-user-ids");
+  if (legacyUserIds !== undefined && legacyUserIds !== null) {
+    const current = get(userIdsByAddressAtom);
+    if (current[address] === undefined) {
+      set(userIdsByAddressAtom, { ...current, [address]: legacyUserIds });
+    }
+  }
+
+  // Remove legacy keys regardless of which fields migrated — anything left
+  // would be re-fetched on demand under the new keys.
+  for (const key of LEGACY_ACCOUNT_KEYS) {
+    localStorage.removeItem(key);
   }
 });
 
@@ -500,6 +678,7 @@ function sleep(ms: number): Promise<void> {
 async function getAllTxs(
   address: string,
   existingTxs: Transaction[],
+  atomGetter: Getter,
   atomSetter: Setter
 ) {
   // Use v1 endpoint which supports offset pagination (v2 uses cursor-based)
@@ -525,10 +704,13 @@ async function getAllTxs(
     const txs = getTransactions();
     const compressedTxs = LZString.compress(JSON.stringify(txs));
 
-    // Check storage before saving - calculate delta vs existing data
+    // Check storage before saving - calculate delta vs existing data for this
+    // address's slice of the per-address record. Other addresses' bytes are
+    // untouched, so they don't contribute to the write delta.
     const newSize = getStringByteSize(compressedTxs);
-    const existingData = localStorage.getItem("citycoins-stacks-acctTxs") || "";
-    const existingSize = getStringByteSize(existingData);
+    const existingForAddress =
+      atomGetter(acctTxsByAddressAtom)[address] || "";
+    const existingSize = getStringByteSize(existingForAddress);
     const deltaSize = newSize - existingSize; // Can be negative if shrinking
     const storageCheck = canSaveData(Math.max(0, deltaSize));
 

--- a/src/store/verification.ts
+++ b/src/store/verification.ts
@@ -515,8 +515,16 @@ export const verifyAllMiningAtom = atom(
       batchUpdates = {};
     };
 
-    // Process entries one by one (rate limited by hiroFetch)
+    // Process entries one by one (rate limited by hiroFetch).
+    // Bail out if the user signs out or switches accounts mid-loop so we
+    // don't keep verifying — and writing results — for a stale address.
+    let cancelled = false;
     for (let i = 0; i < unverified.length; i++) {
+      if (get(stxAddressAtom) !== address) {
+        cancelled = true;
+        break;
+      }
+
       const entry = unverified[i];
       const key = createCacheKey({
         city: entry.city,
@@ -571,7 +579,11 @@ export const verifyAllMiningAtom = atom(
     }
 
     // Persist any remaining results so long verification runs survive refreshes.
-    flushBatchUpdates();
+    // If we cancelled mid-loop the address changed, so flushing would write to
+    // the wrong account's cache — skip it.
+    if (!cancelled) {
+      flushBatchUpdates();
+    }
 
     set(verificationProgressAtom, {
       isRunning: false,
@@ -689,8 +701,9 @@ export const verifyAllStackingAtom = atom(
   null,
   async (get, set, params: { city: CityName; entries: StackingEntry[] }) => {
     const { city, entries } = params;
+    const address = get(stxAddressAtom);
     const userIds = get(userIdsAtom);
-    if (!userIds) {
+    if (!address || !userIds) {
       return;
     }
 
@@ -735,8 +748,16 @@ export const verifyAllStackingAtom = atom(
       batchUpdates = {};
     };
 
-    // Process entries one by one (rate limited by hiroFetch)
+    // Process entries one by one (rate limited by hiroFetch).
+    // Bail out if the user signs out or switches accounts mid-loop so we
+    // don't keep verifying — and writing results — for a stale address.
+    let cancelled = false;
     for (let i = 0; i < unverified.length; i++) {
+      if (get(stxAddressAtom) !== address) {
+        cancelled = true;
+        break;
+      }
+
       const entry = unverified[i];
       const userId = getUserIdForVersion(userIds, entry.city, entry.version)!;
       const key = createCacheKey({
@@ -792,7 +813,11 @@ export const verifyAllStackingAtom = atom(
     }
 
     // Persist any remaining results so long verification runs survive refreshes.
-    flushBatchUpdates();
+    // If we cancelled mid-loop the address changed, so flushing would write to
+    // the wrong account's cache — skip it.
+    if (!cancelled) {
+      flushBatchUpdates();
+    }
 
     set(verificationProgressAtom, {
       isRunning: false,


### PR DESCRIPTION
## Summary
- Cancel in-flight verification loops when the user signs out or switches accounts, and stop the progress banner from lingering with stale state.
- Key per-account atoms (`acctTxs`, `acctMempoolTxs`, `acctBalances`, `userIds`, `bnsName`, `pendingClaims`) by STX address so swapping wallets keeps each account's cache isolated. One-shot migrations move legacy single-key data into the new records under the connected wallet.
- Pre-mark stacking cycles **56, 57, 58, 59, 84** as `no-payout` so users don't burn a verify round-trip (and a button click) on cycles already known to be empty. Cycle 85 stays verifiable — it's the last claim cycle after the shutdown and many stackers legitimately land there.

## Why
Reported in chat: after signing out, the prior account's "Verifying mining claims… 965/4196" banner kept ticking and the loop kept running. The loop captured `address` once at the top, so even after `disconnect()` and `clearUserData()`, results were still being written into the previous wallet's verification cache. The shared-localStorage atoms made the multi-login case worse — leftover data from the prior wallet was visible until the new account's fetch overwrote it.

## Behavioural notes
- `clearUserData` now wipes only the connected wallet's slice from each per-address record. Other accounts' caches survive. Global atoms (active tab, block heights, CCIP-016 state) still reset.
- The cancellation check sits at the top of each verify-all iteration. The in-flight request for the current entry finishes, then the loop exits cleanly; the final batch flush is skipped on cancel so we never write the prior account's results.
- The `no-payout` override is sticky in `verifiedStackingEntriesAtom` — a stale cached "claimable" can't override the hotfix.

## Test plan
- [x] `npx vitest run` — 237/237 pass
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — no new errors (pre-existing Chakra variant typing only)
- [ ] Manual: start a verify-all, sign out mid-loop, confirm the progress banner clears immediately and no further writes hit the prior account's cache.
- [ ] Manual: sign in with wallet A, fetch txs, sign out, sign in with wallet B, confirm wallet A's data is not visible.
- [ ] Manual: sign out then back into wallet A — its cached txs/userIds/BNS/pending claims are still there.
- [ ] Manual: confirm cycles 56-59 and 84 render as "no-payout" with no verify button; cycle 85 still shows the verify/claim flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)