### PR TITLE
Clear MIA pending-approval badge

### DIFF
--- a/src/config/city-claims-config.ts
+++ b/src/config/city-claims-config.ts
@@ -19,7 +19,7 @@ export const CITY_CLAIMS_CONFIG: Record<CityName, CityClaimsConfig> = {
       text: "CCIP-026",
       href: "https://github.com/citycoins/governance/pull/50",
     },
-    pendingApproval: true,
+    pendingApproval: false,
   },
   nyc: {
     cityName: "nyc",


### PR DESCRIPTION
## Summary
- Flip `pendingApproval` to `false` for MIA in `src/config/city-claims-config.ts` so the yellow "Pending approval" badge is removed from the Redeem MIA panel.
- CCIP-026 has passed and the on-chain redemption initialization is in flight (`ccd001-direct-execute` → `ccip026-miamicoin-burn-to-exit`). Once that tx confirms, the contract's `get-redemption-info` will report `redemption-enabled: true` and the UI's Redeem button will unlock automatically — this PR is the only remaining UI-side cleanup, kept separate so it's one-merge-away.

## Test plan
- [ ] Confirm the Redeem MIA accordion no longer shows the yellow "Pending approval" badge
- [ ] Confirm NYC's badge state is unchanged (also `false`)
- [ ] After the activation tx confirms on mainnet, verify the panel reads "Redemption is enabled." and the Redeem button is actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)